### PR TITLE
키보드 컨트롤러 구현

### DIFF
--- a/Runelight-Smash-2021/Assets/Input.meta
+++ b/Runelight-Smash-2021/Assets/Input.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b1e0ab4d9593f4448bdc1cb2e6039c46
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
+++ b/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
@@ -8,7 +8,7 @@
                 {
                     "name": "Jump",
                     "type": "Button",
-                    "id": "0593d91c-ed87-49cf-a0e4-d05a2a47ad8d",
+                    "id": "f79b3d2e-7266-4614-b449-f3db2f43de7f",
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": ""
@@ -17,22 +17,11 @@
             "bindings": [
                 {
                     "name": "",
-                    "id": "cf308899-d1ea-45f3-aa39-8b05308506c3",
+                    "id": "77afc153-5bd2-461d-8694-19f23d9fcca3",
                     "path": "<Keyboard>/space",
-                    "interactions": "",
+                    "interactions": "Tap(duration=0.07)",
                     "processors": "",
-                    "groups": "",
-                    "action": "Jump",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
-                    "id": "b855870f-5ba4-4510-8df2-8908cb946203",
-                    "path": "<Mouse>/leftButton",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": "",
+                    "groups": "Keyboard & Mouse",
                     "action": "Jump",
                     "isComposite": false,
                     "isPartOfComposite": false
@@ -40,5 +29,22 @@
             ]
         }
     ],
-    "controlSchemes": []
+    "controlSchemes": [
+        {
+            "name": "Keyboard & Mouse",
+            "bindingGroup": "Keyboard & Mouse",
+            "devices": [
+                {
+                    "devicePath": "<Keyboard>",
+                    "isOptional": false,
+                    "isOR": false
+                },
+                {
+                    "devicePath": "<Mouse>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        }
+    ]
 }

--- a/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
+++ b/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
@@ -226,6 +226,14 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": ""
+                },
+                {
+                    "name": "MockEdgeGrab",
+                    "type": "Button",
+                    "id": "a9f55573-8cd3-4a2f-a0b1-4470c3258ab1",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
                 }
             ],
             "bindings": [
@@ -303,6 +311,164 @@
                     "processors": "",
                     "groups": "Keyboard & Mouse",
                     "action": "ZAir",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "761d8c94-dca6-48ea-b2b3-b5e7327c2e1c",
+                    "path": "<Keyboard>/q",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "MockEdgeGrab",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "EdgeGrab",
+            "id": "f5938d2c-552c-4308-9d81-430a69b6a53c",
+            "actions": [
+                {
+                    "name": "JumpGetup",
+                    "type": "Button",
+                    "id": "f389ec3f-00a6-4e68-85c5-78c6c51d7659",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "Movement",
+                    "type": "Value",
+                    "id": "13811a88-26b2-44bc-a9f2-7e931d4caaba",
+                    "expectedControlType": "Analog",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "LetGo",
+                    "type": "Button",
+                    "id": "450f9bb4-a7d4-4ef8-8dd4-14adefdeafc3",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "RollGetup",
+                    "type": "Button",
+                    "id": "b71ae4c7-7096-405b-97ba-8de8349f7b2d",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "AttackGetup",
+                    "type": "Button",
+                    "id": "f46b2ca6-007d-466b-8869-b6497d0be87e",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "a5031102-90ec-4fd7-b04e-7379b9bf08ae",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "RollGetup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "1D Axis",
+                    "id": "a7464459-786f-4dca-823d-d2fa280cf366",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Movement",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "negative",
+                    "id": "3c8cf642-60ab-4fac-bff4-7b5c903d7efd",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "Movement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "positive",
+                    "id": "348b3bff-48ad-473f-aed9-c119bcb79838",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "Movement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "4628c60d-1822-4118-89d4-34b21df270bf",
+                    "path": "<Keyboard>/s",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "LetGo",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b149c17c-7b6d-4297-a392-905418cdea55",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "AttackGetup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "679cac58-17ac-499d-ba07-7db85b56db6d",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "AttackGetup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "1cab7105-2bd7-46c1-970d-3877205344da",
+                    "path": "<Keyboard>/e",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "AttackGetup",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "eb9f893b-e66b-4f6b-80fa-9f149cabeab0",
+                    "path": "<Keyboard>/space",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "JumpGetup",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
+++ b/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
@@ -1,0 +1,44 @@
+{
+    "name": "KeyboardControl",
+    "maps": [
+        {
+            "name": "Player",
+            "id": "36a65580-a396-44e3-9091-fcb6d7425f17",
+            "actions": [
+                {
+                    "name": "Jump",
+                    "type": "Button",
+                    "id": "0593d91c-ed87-49cf-a0e4-d05a2a47ad8d",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "cf308899-d1ea-45f3-aa39-8b05308506c3",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "b855870f-5ba4-4510-8df2-8908cb946203",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        }
+    ],
+    "controlSchemes": []
+}

--- a/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
+++ b/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
@@ -44,6 +44,30 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": ""
+                },
+                {
+                    "name": "LeftClick",
+                    "type": "Button",
+                    "id": "fcc6591e-dc63-4156-86d5-40b6d16c9084",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "RightClick",
+                    "type": "Button",
+                    "id": "08bce42f-df06-46f5-923e-77f7cfaed130",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "Attack",
+                    "type": "Value",
+                    "id": "e6b375e8-2d36-4b1c-a888-ce8512c0ff28",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": ""
                 }
             ],
             "bindings": [
@@ -121,6 +145,39 @@
                     "processors": "",
                     "groups": "Keyboard & Mouse",
                     "action": "Grab",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "817c7ff1-2bd2-4757-90f0-eeeff274ac24",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "LeftClick",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c06755df-2c41-4a5c-88b6-a291b8f66b27",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "RightClick",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "3effd1eb-f23a-4d27-9eda-77de26c13006",
+                    "path": "<Mouse>/delta",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "Attack",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
+++ b/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
@@ -28,6 +28,14 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": "Press"
+                },
+                {
+                    "name": "Shield",
+                    "type": "Button",
+                    "id": "88b1b4ca-dcb5-4329-ad96-7515113ad8a9",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
                 }
             ],
             "bindings": [
@@ -85,6 +93,17 @@
                     "action": "Crouch",
                     "isComposite": false,
                     "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "d3399c49-277f-4268-869e-c672bae4a315",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "Shield",
+                    "isComposite": false,
+                    "isPartOfComposite": false
                 }
             ]
         },
@@ -112,6 +131,14 @@
                     "name": "FastFall",
                     "type": "Button",
                     "id": "c07fe02e-aaf8-4a69-8e5b-f551059fbf73",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "AirDodge",
+                    "type": "Button",
+                    "id": "49811574-1efd-416a-bd80-b8af3e33c71c",
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": ""
@@ -170,6 +197,17 @@
                     "processors": "",
                     "groups": "Keyboard & Mouse",
                     "action": "FastFall",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "9d5299c4-c00b-4c30-9a31-d85bf78df8c7",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "AirDodge",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
+++ b/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
@@ -36,6 +36,14 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": ""
+                },
+                {
+                    "name": "Grab",
+                    "type": "Button",
+                    "id": "6a00ddb4-80dc-4bc8-80c2-e3e2ccf694a0",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
                 }
             ],
             "bindings": [
@@ -104,6 +112,17 @@
                     "action": "Shield",
                     "isComposite": false,
                     "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "c67a02f3-67d9-4b84-a050-41c62cb678d5",
+                    "path": "<Keyboard>/e",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "Grab",
+                    "isComposite": false,
+                    "isPartOfComposite": false
                 }
             ]
         },
@@ -139,6 +158,14 @@
                     "name": "AirDodge",
                     "type": "Button",
                     "id": "49811574-1efd-416a-bd80-b8af3e33c71c",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "ZAir",
+                    "type": "Button",
+                    "id": "6956136d-2354-416c-a3ac-44cc77ac4734",
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": ""
@@ -208,6 +235,17 @@
                     "processors": "",
                     "groups": "Keyboard & Mouse",
                     "action": "AirDodge",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "361944b5-2422-40b6-b5ab-4f7e32d27db2",
+                    "path": "<Keyboard>/e",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "ZAir",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
+++ b/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
@@ -20,6 +20,14 @@
                     "expectedControlType": "Analog",
                     "processors": "",
                     "interactions": "Press"
+                },
+                {
+                    "name": "Crouch",
+                    "type": "Button",
+                    "id": "c128e4f3-7f55-40ff-8618-7f3db6901ed2",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press"
                 }
             ],
             "bindings": [
@@ -66,6 +74,17 @@
                     "action": "Movement",
                     "isComposite": false,
                     "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "ef020e3d-9bdc-48e2-b5d4-5b04551be2ab",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "Crouch",
+                    "isComposite": false,
+                    "isPartOfComposite": false
                 }
             ]
         }

--- a/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
+++ b/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
@@ -12,6 +12,14 @@
                     "expectedControlType": "Button",
                     "processors": "",
                     "interactions": ""
+                },
+                {
+                    "name": "Movement",
+                    "type": "Value",
+                    "id": "60f8cacf-117c-45a1-9e7f-7f0814709625",
+                    "expectedControlType": "Analog",
+                    "processors": "",
+                    "interactions": "Press"
                 }
             ],
             "bindings": [
@@ -25,6 +33,39 @@
                     "action": "Jump",
                     "isComposite": false,
                     "isPartOfComposite": false
+                },
+                {
+                    "name": "1D Axis",
+                    "id": "23a622f7-3a0f-4fb7-a4a0-802e1118ade3",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Movement",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "negative",
+                    "id": "c73d881c-e118-4032-855d-1a235912c0e6",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "Movement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "positive",
+                    "id": "c3bb808c-51dd-41a6-935d-586c0951cf42",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "Movement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
                 }
             ]
         }

--- a/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
+++ b/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions
@@ -2,7 +2,7 @@
     "name": "KeyboardControl",
     "maps": [
         {
-            "name": "Player",
+            "name": "Grounded",
             "id": "36a65580-a396-44e3-9091-fcb6d7425f17",
             "actions": [
                 {
@@ -83,6 +83,93 @@
                     "processors": "",
                     "groups": "Keyboard & Mouse",
                     "action": "Crouch",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                }
+            ]
+        },
+        {
+            "name": "Airborne",
+            "id": "3adec105-9002-4076-ae18-aecf31125f29",
+            "actions": [
+                {
+                    "name": "DoubleJump",
+                    "type": "Button",
+                    "id": "9184af8c-3b11-46ec-8d5b-8a2b44b05ee7",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "Movement",
+                    "type": "Value",
+                    "id": "5f842b02-13f3-4075-808b-73215d1d248c",
+                    "expectedControlType": "Analog",
+                    "processors": "",
+                    "interactions": ""
+                },
+                {
+                    "name": "FastFall",
+                    "type": "Button",
+                    "id": "c07fe02e-aaf8-4a69-8e5b-f551059fbf73",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": ""
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "",
+                    "id": "0d4362b0-6fa7-4d3e-a33b-d90b7892f708",
+                    "path": "<Keyboard>/space",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "DoubleJump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "1D Axis",
+                    "id": "c4c9bf86-0445-4d68-be82-7b46d56549eb",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Movement",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "negative",
+                    "id": "db64d66a-5ec4-4dae-b5d6-6fb3d5f68e12",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "Movement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "positive",
+                    "id": "0c6def3e-4040-4cf9-8bc7-99940e85b20a",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "Movement",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "",
+                    "id": "1f939dcb-2fb7-4488-a700-a3f0e634ddc2",
+                    "path": "<Keyboard>/s",
+                    "interactions": "Press",
+                    "processors": "",
+                    "groups": "Keyboard & Mouse",
+                    "action": "FastFall",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions.meta
+++ b/Runelight-Smash-2021/Assets/Input/KeyboardControl.inputactions.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: bc3128d6d2cb3e64cb5dee08dabcd3b4
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 8404be70184654265930450def6a9037, type: 3}
+  generateWrapperCode: 0
+  wrapperCodePath: 
+  wrapperClassName: 
+  wrapperCodeNamespace: 

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -372,6 +372,38 @@ MonoBehaviour:
         m_CallState: 2
     m_ActionId: c07fe02e-aaf8-4a69-8e5b-f551059fbf73
     m_ActionName: Airborne/FastFall[/Keyboard/s]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968841}
+        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+        m_MethodName: HandleShield
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 88b1b4ca-dcb5-4329-ad96-7515113ad8a9
+    m_ActionName: Grounded/Shield[/Keyboard/shift]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968841}
+        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+        m_MethodName: HandleAirDodge
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 49811574-1efd-416a-bd80-b8af3e33c71c
+    m_ActionName: Airborne/AirDodge[/Keyboard/shift]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: Keyboard & Mouse
   m_DefaultActionMap: Grounded

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -118,6 +118,8 @@ NavMeshSettings:
     manualTileSize: 0
     tileSize: 256
     accuratePlacement: 0
+    maxJobWorkers: 0
+    preserveTilesOutsideBounds: 0
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
@@ -204,3 +206,93 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2025968840
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2025968842}
+  - component: {fileID: 2025968843}
+  - component: {fileID: 2025968841}
+  m_Layer: 0
+  m_Name: Fighter
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2025968841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f1100c5662317f34ebbf7286879c1b76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &2025968842
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.7178132, y: -0.17015924, z: -0.46036637}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2025968843
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 62899f850307741f2a39c98a8b639597, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Actions: {fileID: -944628639613478452, guid: bc3128d6d2cb3e64cb5dee08dabcd3b4, type: 3}
+  m_NotificationBehavior: 2
+  m_UIInputModule: {fileID: 0}
+  m_DeviceLostEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_DeviceRegainedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ControlsChangedEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  m_ActionEvents:
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968841}
+        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+        m_MethodName: HandleJump
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: f79b3d2e-7266-4614-b449-f3db2f43de7f
+    m_ActionName: Player/Jump[/Keyboard/space]
+  m_NeverAutoSwitchControlSchemes: 0
+  m_DefaultControlScheme: Keyboard & Mouse
+  m_DefaultActionMap: Player
+  m_SplitScreenIndex: -1
+  m_Camera: {fileID: 0}

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -236,6 +236,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f1100c5662317f34ebbf7286879c1b76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  DASH_BUFFER_DURATION: 0.2
 --- !u!4 &2025968842
 Transform:
   m_ObjectHideFlags: 0
@@ -291,8 +292,88 @@ MonoBehaviour:
         m_CallState: 2
     m_ActionId: f79b3d2e-7266-4614-b449-f3db2f43de7f
     m_ActionName: Player/Jump[/Keyboard/space]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968841}
+        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+        m_MethodName: HandleGroundMovement
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 60f8cacf-117c-45a1-9e7f-7f0814709625
+    m_ActionName: Player/Movement[/Keyboard/w,/Keyboard/s,/Keyboard/a,/Keyboard/d]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968841}
+        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+        m_MethodName: HandleCrouch
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: c128e4f3-7f55-40ff-8618-7f3db6901ed2
+    m_ActionName: Player/Crouch[/Keyboard/s]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968841}
+        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+        m_MethodName: HandleDoubleJump
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 9184af8c-3b11-46ec-8d5b-8a2b44b05ee7
+    m_ActionName: Airborne/DoubleJump[/Keyboard/space]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968841}
+        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+        m_MethodName: HandleAirMovement
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 5f842b02-13f3-4075-808b-73215d1d248c
+    m_ActionName: Airborne/Movement[/Keyboard/a,/Keyboard/d]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968841}
+        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+        m_MethodName: HandleFastFall
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: c07fe02e-aaf8-4a69-8e5b-f551059fbf73
+    m_ActionName: Airborne/FastFall[/Keyboard/s]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: Keyboard & Mouse
-  m_DefaultActionMap: Player
+  m_DefaultActionMap: Grounded
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -404,6 +404,38 @@ MonoBehaviour:
         m_CallState: 2
     m_ActionId: 49811574-1efd-416a-bd80-b8af3e33c71c
     m_ActionName: Airborne/AirDodge[/Keyboard/shift]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968841}
+        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+        m_MethodName: HandleGrab
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 6a00ddb4-80dc-4bc8-80c2-e3e2ccf694a0
+    m_ActionName: Grounded/Grab[/Keyboard/e]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968841}
+        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+        m_MethodName: HandleZAir
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 6956136d-2354-416c-a3ac-44cc77ac4734
+    m_ActionName: Airborne/ZAir[/Keyboard/e]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: Keyboard & Mouse
   m_DefaultActionMap: Grounded

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -220,6 +220,7 @@ GameObject:
   - component: {fileID: 2025968845}
   - component: {fileID: 2025968844}
   - component: {fileID: 2025968846}
+  - component: {fileID: 2025968847}
   m_Layer: 0
   m_Name: Fighter
   m_TagString: Untagged
@@ -239,6 +240,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f1100c5662317f34ebbf7286879c1b76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  isGrounded: 1
 --- !u!4 &2025968842
 Transform:
   m_ObjectHideFlags: 0
@@ -486,6 +488,102 @@ MonoBehaviour:
         m_CallState: 2
     m_ActionId: e6b375e8-2d36-4b1c-a888-ce8512c0ff28
     m_ActionName: Grounded/Attack[/Mouse/delta]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968847}
+        m_TargetAssemblyTypeName: KeyboardEdgeActionHandler, Assembly-CSharp
+        m_MethodName: HandleJumpGetup
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: f389ec3f-00a6-4e68-85c5-78c6c51d7659
+    m_ActionName: EdgeGrab/JumpGetup[/Keyboard/space]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968847}
+        m_TargetAssemblyTypeName: KeyboardEdgeActionHandler, Assembly-CSharp
+        m_MethodName: HandleMovement
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 13811a88-26b2-44bc-a9f2-7e931d4caaba
+    m_ActionName: EdgeGrab/Movement[/Keyboard/a,/Keyboard/d]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968847}
+        m_TargetAssemblyTypeName: KeyboardEdgeActionHandler, Assembly-CSharp
+        m_MethodName: HandleLetGo
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 450f9bb4-a7d4-4ef8-8dd4-14adefdeafc3
+    m_ActionName: EdgeGrab/LetGo[/Keyboard/s]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968847}
+        m_TargetAssemblyTypeName: KeyboardEdgeActionHandler, Assembly-CSharp
+        m_MethodName: HandleRollGetup
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: b71ae4c7-7096-405b-97ba-8de8349f7b2d
+    m_ActionName: EdgeGrab/RollGetup[/Keyboard/shift]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968847}
+        m_TargetAssemblyTypeName: KeyboardEdgeActionHandler, Assembly-CSharp
+        m_MethodName: HandleAttackGetup
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: f46b2ca6-007d-466b-8869-b6497d0be87e
+    m_ActionName: EdgeGrab/AttackGetup[/Mouse/leftButton,/Mouse/rightButton,/Keyboard/e]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968844}
+        m_TargetAssemblyTypeName: KeyboardAirborneActionHandler, Assembly-CSharp
+        m_MethodName: HandleEdgeGrab
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: a9f55573-8cd3-4a2f-a0b1-4470c3258ab1
+    m_ActionName: Airborne/MockEdgeGrab[/Keyboard/q]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: Keyboard & Mouse
   m_DefaultActionMap: Grounded
@@ -529,3 +627,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   MAX_DRAG_DURATION: 0.1
+--- !u!114 &2025968847
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6c555e6e26ee784daf30ffbc7a9bd11, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -219,6 +219,7 @@ GameObject:
   - component: {fileID: 2025968841}
   - component: {fileID: 2025968845}
   - component: {fileID: 2025968844}
+  - component: {fileID: 2025968846}
   m_Layer: 0
   m_Name: Fighter
   m_TagString: Untagged
@@ -437,6 +438,54 @@ MonoBehaviour:
         m_CallState: 2
     m_ActionId: 6956136d-2354-416c-a3ac-44cc77ac4734
     m_ActionName: Airborne/ZAir[/Keyboard/e]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968846}
+        m_TargetAssemblyTypeName: MouseAttackActionHandler, Assembly-CSharp
+        m_MethodName: HandleLeftClick
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: fcc6591e-dc63-4156-86d5-40b6d16c9084
+    m_ActionName: Grounded/LeftClick[/Mouse/leftButton]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968846}
+        m_TargetAssemblyTypeName: MouseAttackActionHandler, Assembly-CSharp
+        m_MethodName: HandleRightClick
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: 08bce42f-df06-46f5-923e-77f7cfaed130
+    m_ActionName: Grounded/RightClick[/Mouse/rightButton]
+  - m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2025968846}
+        m_TargetAssemblyTypeName: MouseAttackActionHandler, Assembly-CSharp
+        m_MethodName: HandleDrag
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+    m_ActionId: e6b375e8-2d36-4b1c-a888-ce8512c0ff28
+    m_ActionName: Grounded/Attack[/Mouse/delta]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: Keyboard & Mouse
   m_DefaultActionMap: Grounded
@@ -467,3 +516,16 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   DASH_BUFFER_DURATION: 0.2
+--- !u!114 &2025968846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b0a308c65431c1745b56e230eb413601, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MAX_DRAG_DURATION: 0.1

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -217,6 +217,8 @@ GameObject:
   - component: {fileID: 2025968842}
   - component: {fileID: 2025968843}
   - component: {fileID: 2025968841}
+  - component: {fileID: 2025968845}
+  - component: {fileID: 2025968844}
   m_Layer: 0
   m_Name: Fighter
   m_TagString: Untagged
@@ -236,7 +238,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f1100c5662317f34ebbf7286879c1b76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  DASH_BUFFER_DURATION: 0.2
 --- !u!4 &2025968842
 Transform:
   m_ObjectHideFlags: 0
@@ -278,8 +279,8 @@ MonoBehaviour:
   m_ActionEvents:
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2025968841}
-        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+      - m_Target: {fileID: 2025968845}
+        m_TargetAssemblyTypeName: KeyboardGroundActionHandler, Assembly-CSharp
         m_MethodName: HandleJump
         m_Mode: 0
         m_Arguments:
@@ -294,8 +295,8 @@ MonoBehaviour:
     m_ActionName: Player/Jump[/Keyboard/space]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2025968841}
-        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+      - m_Target: {fileID: 2025968845}
+        m_TargetAssemblyTypeName: KeyboardGroundActionHandler, Assembly-CSharp
         m_MethodName: HandleGroundMovement
         m_Mode: 0
         m_Arguments:
@@ -310,8 +311,8 @@ MonoBehaviour:
     m_ActionName: Player/Movement[/Keyboard/w,/Keyboard/s,/Keyboard/a,/Keyboard/d]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2025968841}
-        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+      - m_Target: {fileID: 2025968845}
+        m_TargetAssemblyTypeName: KeyboardGroundActionHandler, Assembly-CSharp
         m_MethodName: HandleCrouch
         m_Mode: 0
         m_Arguments:
@@ -326,8 +327,8 @@ MonoBehaviour:
     m_ActionName: Player/Crouch[/Keyboard/s]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2025968841}
-        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+      - m_Target: {fileID: 2025968844}
+        m_TargetAssemblyTypeName: KeyboardAirborneActionHandler, Assembly-CSharp
         m_MethodName: HandleDoubleJump
         m_Mode: 0
         m_Arguments:
@@ -342,8 +343,8 @@ MonoBehaviour:
     m_ActionName: Airborne/DoubleJump[/Keyboard/space]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2025968841}
-        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+      - m_Target: {fileID: 2025968844}
+        m_TargetAssemblyTypeName: KeyboardAirborneActionHandler, Assembly-CSharp
         m_MethodName: HandleAirMovement
         m_Mode: 0
         m_Arguments:
@@ -358,8 +359,8 @@ MonoBehaviour:
     m_ActionName: Airborne/Movement[/Keyboard/a,/Keyboard/d]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2025968841}
-        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+      - m_Target: {fileID: 2025968844}
+        m_TargetAssemblyTypeName: KeyboardAirborneActionHandler, Assembly-CSharp
         m_MethodName: HandleFastFall
         m_Mode: 0
         m_Arguments:
@@ -374,8 +375,8 @@ MonoBehaviour:
     m_ActionName: Airborne/FastFall[/Keyboard/s]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2025968841}
-        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+      - m_Target: {fileID: 2025968845}
+        m_TargetAssemblyTypeName: KeyboardGroundActionHandler, Assembly-CSharp
         m_MethodName: HandleShield
         m_Mode: 0
         m_Arguments:
@@ -390,8 +391,8 @@ MonoBehaviour:
     m_ActionName: Grounded/Shield[/Keyboard/shift]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2025968841}
-        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+      - m_Target: {fileID: 2025968844}
+        m_TargetAssemblyTypeName: KeyboardAirborneActionHandler, Assembly-CSharp
         m_MethodName: HandleAirDodge
         m_Mode: 0
         m_Arguments:
@@ -406,8 +407,8 @@ MonoBehaviour:
     m_ActionName: Airborne/AirDodge[/Keyboard/shift]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2025968841}
-        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+      - m_Target: {fileID: 2025968845}
+        m_TargetAssemblyTypeName: KeyboardGroundActionHandler, Assembly-CSharp
         m_MethodName: HandleGrab
         m_Mode: 0
         m_Arguments:
@@ -422,8 +423,8 @@ MonoBehaviour:
     m_ActionName: Grounded/Grab[/Keyboard/e]
   - m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 2025968841}
-        m_TargetAssemblyTypeName: FighterController, Assembly-CSharp
+      - m_Target: {fileID: 2025968844}
+        m_TargetAssemblyTypeName: KeyboardAirborneActionHandler, Assembly-CSharp
         m_MethodName: HandleZAir
         m_Mode: 0
         m_Arguments:
@@ -441,3 +442,28 @@ MonoBehaviour:
   m_DefaultActionMap: Grounded
   m_SplitScreenIndex: -1
   m_Camera: {fileID: 0}
+--- !u!114 &2025968844
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4cb1090aa47ead459d86f0210e82e4a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2025968845
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c82f8aa7afdec9944bbf4803366e47a1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  DASH_BUFFER_DURATION: 0.2

--- a/Runelight-Smash-2021/Assets/Scripts.meta
+++ b/Runelight-Smash-2021/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 524dba1331ebec64faf82665127ed86a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 207cfb08e3ca0ad4d992e22146e0a437
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardAirborneActionHandler.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardAirborneActionHandler.cs
@@ -19,6 +19,16 @@ public class KeyboardAirborneActionHandler : MonoBehaviour
 
     }
 
+    // Mock Handler to toggle edge grab
+    public void HandleEdgeGrab(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Edge Grab");
+            fighterController.EdgeGrab();
+        }
+    }
+
     public void HandleAirMovement(InputAction.CallbackContext input)
     {
         if (input.performed)

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardAirborneActionHandler.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardAirborneActionHandler.cs
@@ -1,0 +1,77 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class KeyboardAirborneActionHandler : MonoBehaviour
+{
+    private FighterController fighterController;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        fighterController = GetComponent<FighterController>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+
+    }
+
+    public void HandleAirMovement(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            float direction = input.ReadValue<float>();
+
+            if (direction > 0)
+            {
+                Debug.Log("Move Right");
+            }
+            else if (direction < 0)
+            {
+                Debug.Log("Move Left");
+            }
+        }
+        if (input.canceled)
+        {
+            {
+                Debug.Log("Stop");
+            }
+        }
+    }
+
+    public void HandleFastFall(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Fast Fall");
+            fighterController.Land();
+        }
+    }
+
+    public void HandleDoubleJump(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Double Jump");
+        }
+    }
+
+    public void HandleAirDodge(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Air Dodge");
+        }
+    }
+
+    public void HandleZAir(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Zair");
+        }
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardAirborneActionHandler.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardAirborneActionHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4cb1090aa47ead459d86f0210e82e4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardEdgeActionHandler.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardEdgeActionHandler.cs
@@ -1,0 +1,78 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class KeyboardEdgeActionHandler : MonoBehaviour
+{
+    private FighterController fighterController;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        fighterController = GetComponent<FighterController>();
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+
+    }
+
+    public void HandleMovement(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            float direction = input.ReadValue<float>();
+
+            // For now, assume always hanging at the left side
+            if (direction > 0)
+            {
+                Debug.Log("Normal Getup");
+                fighterController.ReleaseEdge();
+            }
+            else if (direction < 0)
+            {
+                Debug.Log("Let Go (Normal)");
+                fighterController.ReleaseEdge();
+            }
+
+        }
+    }
+
+    public void HandleLetGo(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Let Go (Fall)");
+            fighterController.ReleaseEdge();
+        }
+    }
+
+    public void HandleAttackGetup(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Attack Getup");
+            fighterController.ReleaseEdge();
+        }
+    }
+
+    public void HandleJumpGetup(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Jump Getup");
+            fighterController.Jump(1.0f);
+        }
+    }
+
+    public void HandleRollGetup(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Roll Getup");
+            fighterController.ReleaseEdge();
+        }
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardEdgeActionHandler.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardEdgeActionHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6c555e6e26ee784daf30ffbc7a9bd11
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardGroundActionHandler.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardGroundActionHandler.cs
@@ -9,8 +9,6 @@ public class KeyboardGroundActionHandler : MonoBehaviour
 
     private FighterController fighterController;
 
-    private bool isGrounded = true;
-
     private float dashBufferedDirection;
     private Coroutine dashCoroutine;
 
@@ -101,7 +99,7 @@ public class KeyboardGroundActionHandler : MonoBehaviour
 
     public void HandleJump(InputAction.CallbackContext input)
     {
-        if (!isGrounded)
+        if (!fighterController.isGrounded)
         {
             return;
         }

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardGroundActionHandler.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardGroundActionHandler.cs
@@ -1,0 +1,146 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class KeyboardGroundActionHandler : MonoBehaviour
+{
+    public float DASH_BUFFER_DURATION = 0.2f;
+
+    private FighterController fighterController;
+
+    private bool isGrounded = true;
+
+    private float dashBufferedDirection;
+    private Coroutine dashCoroutine;
+
+    private bool isShielding = false;
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        fighterController = GetComponent<FighterController>();
+    }
+
+    public void HandleGroundMovement(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            if (dashCoroutine != null)
+            {
+                StopCoroutine(dashCoroutine);
+            }
+
+            float direction = input.ReadValue<float>();
+
+            if (direction > 0)
+            {
+                if (isShielding)
+                {
+                    Debug.Log("Roll Right");
+                }
+                else if (dashBufferedDirection > 0)
+                {
+                    Debug.Log("Dash Right");
+                    dashBufferedDirection = 0.0f;
+                }
+                else
+                {
+                    Debug.Log("Move Right");
+                    dashBufferedDirection = direction;
+                    dashCoroutine = StartCoroutine(DashBuffer());
+                }
+            }
+            else if (direction < 0)
+            {
+                if (isShielding)
+                {
+                    Debug.Log("Roll Left");
+                }
+                else if (dashBufferedDirection < 0)
+                {
+                    Debug.Log("Dash Left");
+                    dashBufferedDirection = 0.0f;
+                }
+                else
+                {
+                    Debug.Log("Move Left");
+                    dashBufferedDirection = direction;
+                    dashCoroutine = StartCoroutine(DashBuffer());
+                }
+            }
+        }
+        if (input.canceled)
+        {
+            {
+                Debug.Log("Stop");
+            }
+        }
+    }
+
+    IEnumerator DashBuffer()
+    {
+        yield return new WaitForSeconds(DASH_BUFFER_DURATION);
+        dashBufferedDirection = 0.0f;
+    }
+
+    public void HandleCrouch(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            if (isShielding)
+            {
+                Debug.Log("Spot Dodge");
+            }
+            else
+            {
+                Debug.Log("Crouch");
+            }
+        }
+    }
+
+    public void HandleJump(InputAction.CallbackContext input)
+    {
+        if (!isGrounded)
+        {
+            return;
+        }
+        if (input.started)
+        {
+            Debug.Log("Jump Started");
+        }
+        if (input.performed)
+        {
+            Debug.Log("Short Hop");
+            // TODO: Use Event System to trigger character action
+            fighterController.Jump(0.5f);
+        }
+        if (input.canceled)
+        {
+            Debug.Log("Full Hop");
+            fighterController.Jump(1.0f);
+        }
+    }
+
+    public void HandleShield(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Shield");
+            isShielding = true;
+        }
+        if (input.canceled)
+        {
+            Debug.Log("Shield Release");
+            isShielding = false;
+        }
+    }
+
+    public void HandleGrab(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Grab");
+        }
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardGroundActionHandler.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler/KeyboardGroundActionHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c82f8aa7afdec9944bbf4803366e47a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler/MouseAttackActionHandler.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler/MouseAttackActionHandler.cs
@@ -1,0 +1,100 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+// TODO: Change to Custom Composite Interaction
+public class MouseAttackActionHandler : MonoBehaviour
+{
+    public float MAX_DRAG_DURATION = 0.1f;
+    private Coroutine dragTimer;
+
+    private bool isClicked = false;
+    private Vector2 accumulatedDragVector = new Vector2();
+
+    // Start is called before the first frame update
+    void Start()
+    {
+
+    }
+
+    public void HandleClick(InputAction.CallbackContext input, System.Action OnRelease)
+    {
+        if (input.performed)
+        {
+            if (dragTimer != null)
+            {
+                return;
+            }
+            isClicked = true;
+            dragTimer = StartCoroutine(DragTimer(OnRelease));
+            Cursor.lockState = CursorLockMode.Locked;
+        }
+        if (input.canceled)
+        {
+            if (dragTimer != null)
+            {
+                StopCoroutine(dragTimer);
+                OnRelease();
+                Reset();
+            }
+        }
+    }
+
+    public void HandleLeftClick(InputAction.CallbackContext input)
+    {
+        System.Action OnRelease = () =>
+        {
+            Debug.Log($"Attack {GetDirectionAngle(accumulatedDragVector)} degree {GetMagnitude(accumulatedDragVector)} strength");
+
+        };
+
+        HandleClick(input, OnRelease);
+    }
+
+    public void HandleRightClick(InputAction.CallbackContext input)
+    {
+        System.Action OnRelease = () =>
+        {
+            Debug.Log($"Special {GetDirectionAngle(accumulatedDragVector)} degree {GetMagnitude(accumulatedDragVector)} strength");
+        };
+
+        HandleClick(input, OnRelease);
+    }
+
+    public void HandleDrag(InputAction.CallbackContext input)
+    {
+        if (!input.performed)
+        {
+            return;
+        }
+        if (isClicked)
+        {
+            accumulatedDragVector += input.ReadValue<Vector2>();
+        }
+    }
+
+    private float GetDirectionAngle(Vector2 direction)
+    {
+        return Vector2.SignedAngle(Vector2.right, direction);
+    }
+
+    private float GetMagnitude(Vector2 direction)
+    {
+        return Vector2.SqrMagnitude(direction);
+    }
+
+    private void Reset()
+    {
+        accumulatedDragVector = new Vector2();
+        isClicked = false;
+        dragTimer = null;
+    }
+
+    IEnumerator DragTimer(System.Action OnRelease)
+    {
+        yield return new WaitForSeconds(MAX_DRAG_DURATION);
+        OnRelease();
+        Reset();
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler/MouseAttackActionHandler.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler/MouseAttackActionHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0a308c65431c1745b56e230eb413601
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -14,6 +14,8 @@ public class FighterController : MonoBehaviour
     private float dashBufferedDirection;
     private Coroutine dashCoroutine;
 
+    private bool isShielding = false;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -39,7 +41,11 @@ public class FighterController : MonoBehaviour
 
             if (direction > 0)
             {
-                if (dashBufferedDirection > 0)
+                if (isShielding)
+                {
+                    Debug.Log("Roll Right");
+                }
+                else if (dashBufferedDirection > 0)
                 {
                     Debug.Log("Dash Right");
                     dashBufferedDirection = 0.0f;
@@ -53,7 +59,11 @@ public class FighterController : MonoBehaviour
             }
             else if (direction < 0)
             {
-                if (dashBufferedDirection < 0)
+                if (isShielding)
+                {
+                    Debug.Log("Roll Left");
+                }
+                else if (dashBufferedDirection < 0)
                 {
                     Debug.Log("Dash Left");
                     dashBufferedDirection = 0.0f;
@@ -84,11 +94,14 @@ public class FighterController : MonoBehaviour
     {
         if (input.performed)
         {
-
+            if (isShielding)
+            {
+                Debug.Log("Spot Dodge");
+            }
+            else
             {
                 Debug.Log("Crouch");
             }
-
         }
     }
 
@@ -111,6 +124,20 @@ public class FighterController : MonoBehaviour
         {
             Debug.Log("Full Hop");
             Jump(1.0f);
+        }
+    }
+
+    public void HandleShield(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Shield");
+            isShielding = true;
+        }
+        if (input.canceled)
+        {
+            Debug.Log("Shield Release");
+            isShielding = false;
         }
     }
 
@@ -165,6 +192,14 @@ public class FighterController : MonoBehaviour
         if (input.performed)
         {
             Debug.Log("Double Jump");
+        }
+    }
+
+    public void HandleAirDodge(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Air Dodge");
         }
     }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -141,6 +141,14 @@ public class FighterController : MonoBehaviour
         }
     }
 
+    public void HandleGrab(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Grab");
+        }
+    }
+
     // Mock jump simulation
     private void Jump(float duration)
     {
@@ -200,6 +208,14 @@ public class FighterController : MonoBehaviour
         if (input.performed)
         {
             Debug.Log("Air Dodge");
+        }
+    }
+
+    public void HandleZAir(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Zair");
         }
     }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+public class FighterController : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+
+    }
+
+    public void HandleJump(InputAction.CallbackContext input)
+    {
+        if (input.started)
+        {
+            Debug.Log("Jump Started");
+        }
+        if (input.performed)
+        {
+            Debug.Log("Short Hop");
+        }
+        if (input.canceled)
+        {
+            Debug.Log("Full Hop");
+        }
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -5,16 +5,9 @@ using UnityEngine.InputSystem;
 
 public class FighterController : MonoBehaviour
 {
-    public float DASH_BUFFER_DURATION = 0.2f;
-
     private PlayerInput playerInput;
 
     private bool isGrounded = true;
-
-    private float dashBufferedDirection;
-    private Coroutine dashCoroutine;
-
-    private bool isShielding = false;
 
     // Start is called before the first frame update
     void Start()
@@ -22,200 +15,17 @@ public class FighterController : MonoBehaviour
         playerInput = GetComponent<PlayerInput>();
     }
 
-    // Update is called once per frame
-    void Update()
-    {
-
-    }
-
-    public void HandleGroundMovement(InputAction.CallbackContext input)
-    {
-        if (input.performed)
-        {
-            if (dashCoroutine != null)
-            {
-                StopCoroutine(dashCoroutine);
-            }
-
-            float direction = input.ReadValue<float>();
-
-            if (direction > 0)
-            {
-                if (isShielding)
-                {
-                    Debug.Log("Roll Right");
-                }
-                else if (dashBufferedDirection > 0)
-                {
-                    Debug.Log("Dash Right");
-                    dashBufferedDirection = 0.0f;
-                }
-                else
-                {
-                    Debug.Log("Move Right");
-                    dashBufferedDirection = direction;
-                    dashCoroutine = StartCoroutine(DashBuffer());
-                }
-            }
-            else if (direction < 0)
-            {
-                if (isShielding)
-                {
-                    Debug.Log("Roll Left");
-                }
-                else if (dashBufferedDirection < 0)
-                {
-                    Debug.Log("Dash Left");
-                    dashBufferedDirection = 0.0f;
-                }
-                else
-                {
-                    Debug.Log("Move Left");
-                    dashBufferedDirection = direction;
-                    dashCoroutine = StartCoroutine(DashBuffer());
-                }
-            }
-        }
-        if (input.canceled)
-        {
-            {
-                Debug.Log("Stop");
-            }
-        }
-    }
-
-    IEnumerator DashBuffer()
-    {
-        yield return new WaitForSeconds(DASH_BUFFER_DURATION);
-        dashBufferedDirection = 0.0f;
-    }
-
-    public void HandleCrouch(InputAction.CallbackContext input)
-    {
-        if (input.performed)
-        {
-            if (isShielding)
-            {
-                Debug.Log("Spot Dodge");
-            }
-            else
-            {
-                Debug.Log("Crouch");
-            }
-        }
-    }
-
-    public void HandleJump(InputAction.CallbackContext input)
-    {
-        if (!isGrounded)
-        {
-            return;
-        }
-        if (input.started)
-        {
-            Debug.Log("Jump Started");
-        }
-        if (input.performed)
-        {
-            Debug.Log("Short Hop");
-            Jump(0.5f);
-        }
-        if (input.canceled)
-        {
-            Debug.Log("Full Hop");
-            Jump(1.0f);
-        }
-    }
-
-    public void HandleShield(InputAction.CallbackContext input)
-    {
-        if (input.performed)
-        {
-            Debug.Log("Shield");
-            isShielding = true;
-        }
-        if (input.canceled)
-        {
-            Debug.Log("Shield Release");
-            isShielding = false;
-        }
-    }
-
-    public void HandleGrab(InputAction.CallbackContext input)
-    {
-        if (input.performed)
-        {
-            Debug.Log("Grab");
-        }
-    }
-
     // Mock jump simulation
-    private void Jump(float duration)
+    public void Jump(float duration)
     {
         isGrounded = false;
         playerInput.SwitchCurrentActionMap("Airborne");
     }
 
-    private void Land()
+    public void Land()
     {
         playerInput.SwitchCurrentActionMap("Grounded");
         isGrounded = true;
         Debug.Log("Landed");
-    }
-
-    public void HandleAirMovement(InputAction.CallbackContext input)
-    {
-        if (input.performed)
-        {
-            float direction = input.ReadValue<float>();
-
-            if (direction > 0)
-            {
-                Debug.Log("Move Right");
-            }
-            else if (direction < 0)
-            {
-                Debug.Log("Move Left");
-            }
-        }
-        if (input.canceled)
-        {
-            {
-                Debug.Log("Stop");
-            }
-        }
-    }
-
-    public void HandleFastFall(InputAction.CallbackContext input)
-    {
-        if (input.performed)
-        {
-            Debug.Log("Fast Fall");
-            Land();
-        }
-    }
-
-    public void HandleDoubleJump(InputAction.CallbackContext input)
-    {
-        if (input.performed)
-        {
-            Debug.Log("Double Jump");
-        }
-    }
-
-    public void HandleAirDodge(InputAction.CallbackContext input)
-    {
-        if (input.performed)
-        {
-            Debug.Log("Air Dodge");
-        }
-    }
-
-    public void HandleZAir(InputAction.CallbackContext input)
-    {
-        if (input.performed)
-        {
-            Debug.Log("Zair");
-        }
     }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -77,6 +77,14 @@ public class FighterController : MonoBehaviour
         Debug.Log("Buffer Over");
     }
 
+    public void HandleCrouch(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Crouch");
+        }
+    }
+
     public void HandleJump(InputAction.CallbackContext input)
     {
         if (input.started)

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -7,7 +7,7 @@ public class FighterController : MonoBehaviour
 {
     private PlayerInput playerInput;
 
-    private bool isGrounded = true;
+    public bool isGrounded = true;
 
     // Start is called before the first frame update
     void Start()
@@ -27,5 +27,17 @@ public class FighterController : MonoBehaviour
         playerInput.SwitchCurrentActionMap("Grounded");
         isGrounded = true;
         Debug.Log("Landed");
+    }
+
+    // Mock edge grab simulation
+    public void EdgeGrab()
+    {
+        playerInput.SwitchCurrentActionMap("EdgeGrab");
+    }
+
+    public void ReleaseEdge()
+    {
+        playerInput.SwitchCurrentActionMap("Grounded");
+        isGrounded = true;
     }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -7,13 +7,17 @@ public class FighterController : MonoBehaviour
 {
     public float DASH_BUFFER_DURATION = 0.2f;
 
+    private PlayerInput playerInput;
+
+    private bool isGrounded = true;
+
     private float dashBufferedDirection;
     private Coroutine dashCoroutine;
 
     // Start is called before the first frame update
     void Start()
     {
-
+        playerInput = GetComponent<PlayerInput>();
     }
 
     // Update is called once per frame
@@ -22,7 +26,7 @@ public class FighterController : MonoBehaviour
 
     }
 
-    public void HandleMovement(InputAction.CallbackContext input)
+    public void HandleGroundMovement(InputAction.CallbackContext input)
     {
         if (input.performed)
         {
@@ -74,19 +78,26 @@ public class FighterController : MonoBehaviour
     {
         yield return new WaitForSeconds(DASH_BUFFER_DURATION);
         dashBufferedDirection = 0.0f;
-        Debug.Log("Buffer Over");
     }
 
     public void HandleCrouch(InputAction.CallbackContext input)
     {
         if (input.performed)
         {
-            Debug.Log("Crouch");
+
+            {
+                Debug.Log("Crouch");
+            }
+
         }
     }
 
     public void HandleJump(InputAction.CallbackContext input)
     {
+        if (!isGrounded)
+        {
+            return;
+        }
         if (input.started)
         {
             Debug.Log("Jump Started");
@@ -94,10 +105,66 @@ public class FighterController : MonoBehaviour
         if (input.performed)
         {
             Debug.Log("Short Hop");
+            Jump(0.5f);
         }
         if (input.canceled)
         {
             Debug.Log("Full Hop");
+            Jump(1.0f);
+        }
+    }
+
+    // Mock jump simulation
+    private void Jump(float duration)
+    {
+        isGrounded = false;
+        playerInput.SwitchCurrentActionMap("Airborne");
+    }
+
+    private void Land()
+    {
+        playerInput.SwitchCurrentActionMap("Grounded");
+        isGrounded = true;
+        Debug.Log("Landed");
+    }
+
+    public void HandleAirMovement(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            float direction = input.ReadValue<float>();
+
+            if (direction > 0)
+            {
+                Debug.Log("Move Right");
+            }
+            else if (direction < 0)
+            {
+                Debug.Log("Move Left");
+            }
+        }
+        if (input.canceled)
+        {
+            {
+                Debug.Log("Stop");
+            }
+        }
+    }
+
+    public void HandleFastFall(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Fast Fall");
+            Land();
+        }
+    }
+
+    public void HandleDoubleJump(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            Debug.Log("Double Jump");
         }
     }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -5,6 +5,11 @@ using UnityEngine.InputSystem;
 
 public class FighterController : MonoBehaviour
 {
+    public float DASH_BUFFER_DURATION = 0.2f;
+
+    private float dashBufferedDirection;
+    private Coroutine dashCoroutine;
+
     // Start is called before the first frame update
     void Start()
     {
@@ -15,6 +20,61 @@ public class FighterController : MonoBehaviour
     void Update()
     {
 
+    }
+
+    public void HandleMovement(InputAction.CallbackContext input)
+    {
+        if (input.performed)
+        {
+            if (dashCoroutine != null)
+            {
+                StopCoroutine(dashCoroutine);
+            }
+
+            float direction = input.ReadValue<float>();
+
+            if (direction > 0)
+            {
+                if (dashBufferedDirection > 0)
+                {
+                    Debug.Log("Dash Right");
+                    dashBufferedDirection = 0.0f;
+                }
+                else
+                {
+                    Debug.Log("Move Right");
+                    dashBufferedDirection = direction;
+                    dashCoroutine = StartCoroutine(DashBuffer());
+                }
+            }
+            else if (direction < 0)
+            {
+                if (dashBufferedDirection < 0)
+                {
+                    Debug.Log("Dash Left");
+                    dashBufferedDirection = 0.0f;
+                }
+                else
+                {
+                    Debug.Log("Move Left");
+                    dashBufferedDirection = direction;
+                    dashCoroutine = StartCoroutine(DashBuffer());
+                }
+            }
+        }
+        if (input.canceled)
+        {
+            {
+                Debug.Log("Stop");
+            }
+        }
+    }
+
+    IEnumerator DashBuffer()
+    {
+        yield return new WaitForSeconds(DASH_BUFFER_DURATION);
+        dashBufferedDirection = 0.0f;
+        Debug.Log("Buffer Over");
     }
 
     public void HandleJump(InputAction.CallbackContext input)

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f1100c5662317f34ebbf7286879c1b76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Packages/manifest.json
+++ b/Runelight-Smash-2021/Packages/manifest.json
@@ -10,6 +10,7 @@
     "com.unity.ide.rider": "2.0.7",
     "com.unity.ide.visualstudio": "2.0.9",
     "com.unity.ide.vscode": "1.2.3",
+    "com.unity.inputsystem": "1.0.2",
     "com.unity.test-framework": "1.1.26",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.4.8",

--- a/Runelight-Smash-2021/Packages/packages-lock.json
+++ b/Runelight-Smash-2021/Packages/packages-lock.json
@@ -113,6 +113,13 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.inputsystem": {
+      "version": "1.0.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
     "com.unity.mathematics": {
       "version": "1.1.0",
       "depth": 1,

--- a/Runelight-Smash-2021/ProjectSettings/ProjectSettings.asset
+++ b/Runelight-Smash-2021/ProjectSettings/ProjectSettings.asset
@@ -636,7 +636,7 @@ PlayerSettings:
     m_VersionCode: 1
     m_VersionName: 
   apiCompatibilityLevel: 6
-  activeInputHandler: 0
+  activeInputHandler: 1
   cloudProjectId: 
   framebufferDepthMemorylessMode: 0
   qualitySettingsNames: []


### PR DESCRIPTION
## 이슈 번호
* #1 

## 작업 내역
* 신 InputSystem 을 사용해보면서 키보드 입력 시스템 구현
  * 점프 키 입력 시간에 따라 Short Hop / Full Hop 입력 구분
  * 좌우 이동 / 이동 키 더블 탭 시 대쉬 입력
  * 실드 키를 이용한 실드, 구르기, 공중 회피 등 입력 구분

## 리뷰받고 싶은 Point
* 지상 / 공중 / 매달리기 상태에 따라 Action Map 을 바꾸도록 구현하였는데, Action Map을 바꾸면 InputAction 콜백이 불리면서 유니티에서 Index 에러가 터진다... (현재는 [플래그](https://github.com/andrewpk95/Runelight-Smash-2021/commit/dce700347d4c12ee517983abe12a41b0ef622ae7#diff-c129b5f1bd0b64cbc3b5426cac9f12a21e2baf08e9f811f342811500f462541aR102-R105) 로 코드 실행을 막아서 해결한 상태)
* 캐릭터를 조종하는 Input 을 구현할 때:
  * 상태에 따라 Action Map 을 바꾸는 방식으로 하면 코드 내에서 플래그에 따라 분기처리하는 내용을 없앨 수 있으나 Action Map 교체 과정에서 오류가 나기 쉬움
  * 한 개의 Action Map 에서 모두 관리하면 코드 내에서 플래그로 분기 처리하는 부분이 많아져서 (공중 상태인지, 실드 상태인지 등) 코드가 많아지고 지저분해질 것 같은데
* 어느 방식이 좋은 방식일 지...