### PR TITLE
기본 경사면 이동 구현

### DIFF
--- a/Runelight-Smash-2021/Assets/PhysicsMaterial.meta
+++ b/Runelight-Smash-2021/Assets/PhysicsMaterial.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec5c28e624530ce498471fc9401e0b7c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/PhysicsMaterial/NoFriction.physicsMaterial2D
+++ b/Runelight-Smash-2021/Assets/PhysicsMaterial/NoFriction.physicsMaterial2D
@@ -1,0 +1,11 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!62 &6200000
+PhysicsMaterial2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: NoFriction
+  friction: 0
+  bounciness: 0

--- a/Runelight-Smash-2021/Assets/PhysicsMaterial/NoFriction.physicsMaterial2D.meta
+++ b/Runelight-Smash-2021/Assets/PhysicsMaterial/NoFriction.physicsMaterial2D.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b075c48d34681248ab9e4aadaeb0e7f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 6200000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1986,6 +1986,8 @@ MonoBehaviour:
   rightMostSlopeAngle: 0
   leftMostSlopeDirection: {x: 0, y: 0}
   rightMostSlopeDirection: {x: 0, y: 0}
+  canWalkOnSlope: 0
+  maxSlopeAngle: 45
   onLandEvent:
     m_PersistentCalls:
       m_Calls: []

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1992,7 +1992,7 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   maxWalkSpeed: 4
-  walkAccelerationRate: 1000
+  walkAccelerationRate: 15
   groundDecelerationRate: 20
   maxAirSpeed: 3
   airAccelerationRate: 8

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -2000,6 +2000,7 @@ MonoBehaviour:
   doubleJumpHeight: 3
   maxDoubleJumpCount: 1
   canJumpChangeDirection: 1
+  minSlopeJumpAngle: 15
   onJumpEvent:
     m_PersistentCalls:
       m_Calls: []

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1956,8 +1956,8 @@ CapsuleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: -0.1}
-  m_Size: {x: 0.4, y: 1.5}
+  m_Offset: {x: 0, y: -0.3}
+  m_Size: {x: 0.4, y: 1}
   m_Direction: 0
 --- !u!114 &2025968851
 MonoBehaviour:
@@ -1973,12 +1973,13 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   velocity: {x: 0, y: 0}
   feetPosition: {fileID: 442199920}
-  groundCheckRadius: 0.2
+  groundCheckRadius: 0.17
   groundLayerMask:
     serializedVersion: 2
     m_Bits: 64
   gravity: 20
   maxFallSpeed: 5
+  isGrounded: 0
   _isGrounded: 0
   isOnSlope: 0
   leftMostSlopeAngle: 0

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1473,7 +1473,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2025968840}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.15, y: -0.2, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 519420032}
@@ -1973,7 +1973,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   velocity: {x: 0, y: 0}
   feetPosition: {fileID: 442199920}
-  groundCheckRadius: 0.17
+  groundCheckRadius: 0.2
   groundLayerMask:
     serializedVersion: 2
     m_Bits: 64

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -123,6 +123,170 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &168727202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 168727206}
+  - component: {fileID: 168727205}
+  m_Layer: 6
+  m_Name: Platform (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &168727205
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 168727202}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f773b62820c9f25408f12e4d6c38bd14, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &168727206
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 168727202}
+  m_LocalRotation: {x: 0, y: 0, z: 0.38268343, w: 0.92387956}
+  m_LocalPosition: {x: 4.2, y: -1.96, z: 9.427856}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
+--- !u!1 &410358853
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 410358857}
+  - component: {fileID: 410358856}
+  m_Layer: 6
+  m_Name: Platform (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &410358856
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 410358853}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f773b62820c9f25408f12e4d6c38bd14, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &410358857
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 410358853}
+  m_LocalRotation: {x: -0, y: -0, z: -0.5, w: 0.8660254}
+  m_LocalPosition: {x: -4.68, y: 0.86, z: 9.427856}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -60}
 --- !u!1 &418088294
 GameObject:
   m_ObjectHideFlags: 0
@@ -152,7 +316,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 2025968842}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!212 &418088296
 SpriteRenderer:
@@ -234,7 +398,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 2025968842}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!58 &442199921
 CircleCollider2D:
@@ -243,7 +407,7 @@ CircleCollider2D:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 442199919}
-  m_Enabled: 1
+  m_Enabled: 0
   m_Density: 1
   m_Material: {fileID: 0}
   m_IsTrigger: 1
@@ -252,6 +416,88 @@ CircleCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Radius: 0.2
+--- !u!1 &506207282
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 506207286}
+  - component: {fileID: 506207285}
+  m_Layer: 6
+  m_Name: Platform (11)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &506207285
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 506207282}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f773b62820c9f25408f12e4d6c38bd14, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &506207286
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 506207282}
+  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: 11.176325, y: 0.69080126, z: 9.427856}
+  m_LocalScale: {x: 2, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -305,7 +551,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 5
+  orthographic size: 3
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2
@@ -328,13 +574,95 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 2025968842}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &600588056
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 600588060}
+  - component: {fileID: 600588059}
+  m_Layer: 6
+  m_Name: Platform (10)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &600588059
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 600588056}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f773b62820c9f25408f12e4d6c38bd14, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &600588060
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 600588056}
+  m_LocalRotation: {x: -0, y: -0, z: 0.38268343, w: 0.92387956}
+  m_LocalPosition: {x: 9.53, y: -2.66, z: 9.427856}
+  m_LocalScale: {x: 2, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 45}
 --- !u!1 &623329811
 GameObject:
   m_ObjectHideFlags: 0
@@ -345,8 +673,6 @@ GameObject:
   m_Component:
   - component: {fileID: 623329813}
   - component: {fileID: 623329812}
-  - component: {fileID: 623329815}
-  - component: {fileID: 623329814}
   m_Layer: 6
   m_Name: Platform
   m_TagString: Untagged
@@ -412,21 +738,681 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 623329811}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -2, z: 0}
-  m_LocalScale: {x: 6, y: 1, z: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1.956325, y: -2.11, z: 9.427856}
+  m_LocalScale: {x: 2, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!50 &623329814
+--- !u!1 &636402038
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 636402042}
+  - component: {fileID: 636402041}
+  m_Layer: 6
+  m_Name: Platform (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &636402041
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 636402038}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f773b62820c9f25408f12e4d6c38bd14, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &636402042
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 636402038}
+  m_LocalRotation: {x: -0, y: -0, z: -0.258819, w: 0.9659259}
+  m_LocalPosition: {x: 0.03, y: -2.25, z: 9.427856}
+  m_LocalScale: {x: 2, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -30}
+--- !u!1 &639549713
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 639549717}
+  - component: {fileID: 639549716}
+  m_Layer: 6
+  m_Name: Platform (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &639549716
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 639549713}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f773b62820c9f25408f12e4d6c38bd14, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &639549717
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 639549713}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -6.19, y: 1.8, z: 9.427856}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &911326940
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 911326944}
+  - component: {fileID: 911326943}
+  m_Layer: 6
+  m_Name: Platform (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &911326943
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 911326940}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f773b62820c9f25408f12e4d6c38bd14, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &911326944
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 911326940}
+  m_LocalRotation: {x: -0, y: -0, z: -0.258819, w: 0.9659259}
+  m_LocalPosition: {x: 5.92, y: -1.7, z: 9.427856}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -30}
+--- !u!1 &1123981623
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1123981627}
+  - component: {fileID: 1123981626}
+  m_Layer: 6
+  m_Name: Platform (9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1123981626
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1123981623}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f773b62820c9f25408f12e4d6c38bd14, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1123981627
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1123981623}
+  m_LocalRotation: {x: -0, y: -0, z: -0.5, w: 0.8660254}
+  m_LocalPosition: {x: 7.31, y: -3.17, z: 9.427856}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -60}
+--- !u!1 &1147417095
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1147417099}
+  - component: {fileID: 1147417098}
+  m_Layer: 6
+  m_Name: Platform (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1147417098
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1147417095}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f773b62820c9f25408f12e4d6c38bd14, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1147417099
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1147417095}
+  m_LocalRotation: {x: -0, y: -0, z: -0.38268343, w: 0.92387956}
+  m_LocalPosition: {x: -3.76, y: -0.46, z: 9.427856}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -45}
+--- !u!1 &1201941612
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1201941616}
+  - component: {fileID: 1201941615}
+  m_Layer: 6
+  m_Name: Platform (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1201941615
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1201941612}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f773b62820c9f25408f12e4d6c38bd14, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1201941616
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1201941612}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3.19, y: -1.19, z: 9.427856}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1387743321
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1387743325}
+  - component: {fileID: 1387743324}
+  m_Layer: 6
+  m_Name: Platform (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!212 &1387743324
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1387743321}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: f773b62820c9f25408f12e4d6c38bd14, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 20, y: 2}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!4 &1387743325
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1387743321}
+  m_LocalRotation: {x: -0, y: -0, z: -0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -7.19, y: 2.79, z: 9.427856}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1457690516}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: -90}
+--- !u!1 &1457690514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1457690516}
+  - component: {fileID: 1457690515}
+  - component: {fileID: 1457690517}
+  m_Layer: 6
+  m_Name: Ground
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!60 &1457690515
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1457690514}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: 8, y: -4}
+      - {x: 7, y: -2}
+      - {x: 5, y: -1}
+      - {x: 4, y: -2}
+      - {x: 0, y: -2}
+      - {x: -2, y: -1}
+      - {x: -3, y: -1}
+      - {x: -4, y: 0}
+      - {x: -5, y: 2}
+      - {x: -7, y: 2}
+      - {x: -7, y: 4}
+      - {x: -8, y: 4}
+      - {x: -8, y: -5}
+      - {x: 12, y: -5}
+      - {x: 12, y: 3}
+      - {x: 11, y: 3}
+      - {x: 11, y: -1}
+--- !u!4 &1457690516
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1457690514}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -1.956325, y: 0.029198777, z: -9.427856}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 623329813}
+  - {fileID: 168727206}
+  - {fileID: 636402042}
+  - {fileID: 1201941616}
+  - {fileID: 1147417099}
+  - {fileID: 410358857}
+  - {fileID: 639549717}
+  - {fileID: 1387743325}
+  - {fileID: 911326944}
+  - {fileID: 1123981627}
+  - {fileID: 600588060}
+  - {fileID: 506207286}
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &1457690517
 Rigidbody2D:
   serializedVersion: 4
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 623329811}
+  m_GameObject: {fileID: 1457690514}
   m_BodyType: 2
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
@@ -440,32 +1426,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!61 &623329815
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 623329811}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 2.3529413, y: 0.23529412}
-    newSize: {x: 20, y: 2}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 2.3529413, y: 0.23529412}
-  m_EdgeRadius: 0
 --- !u!1 &2025968840
 GameObject:
   m_ObjectHideFlags: 0
@@ -513,13 +1473,14 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2025968840}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.15, y: -0.2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 519420032}
   - {fileID: 418088295}
   - {fileID: 442199920}
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2025968843
 MonoBehaviour:
@@ -1019,11 +1980,16 @@ MonoBehaviour:
   gravity: 20
   maxFallSpeed: 5
   _isGrounded: 0
+  isOnSlope: 0
+  leftMostSlopeAngle: 0
+  rightMostSlopeAngle: 0
+  leftMostSlopeDirection: {x: 0, y: 0}
+  rightMostSlopeDirection: {x: 0, y: 0}
   onLandEvent:
     m_PersistentCalls:
       m_Calls: []
-  maxWalkSpeed: 5
-  walkAccelerationRate: 15
+  maxWalkSpeed: 4
+  walkAccelerationRate: 1000
   groundDecelerationRate: 20
   maxAirSpeed: 3
   airAccelerationRate: 8

--- a/Runelight-Smash-2021/Assets/Scripts/Character/BaseUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/BaseUnit.cs
@@ -21,6 +21,11 @@ public class BaseUnit : MonoBehaviour
 
     protected virtual void FixedUpdate()
     {
+        Tick();
+    }
+
+    protected virtual void Tick()
+    {
         if (isMovementEnabled)
         {
             ApplyVelocity();

--- a/Runelight-Smash-2021/Assets/Scripts/Character/BaseUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/BaseUnit.cs
@@ -6,6 +6,7 @@ public class BaseUnit : MonoBehaviour
 {
     protected Collider2D unitCollider;
     protected Rigidbody2D unitRigidbody;
+    protected Vector2 prevPosition;
 
     [SerializeField]
     protected Vector2 velocity;
@@ -34,6 +35,7 @@ public class BaseUnit : MonoBehaviour
 
     private void ApplyVelocity()
     {
+        prevPosition = unitRigidbody.position;
         unitRigidbody.MovePosition(unitRigidbody.position + velocity * Time.fixedDeltaTime);
     }
 

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -68,6 +68,10 @@ public class ControllableUnit : PhysicsUnit
 
     protected virtual void ApplyGroundMovement()
     {
+        if (!canWalkOnSlope)
+        {
+            return;
+        }
         float walkSpeed = joystick.x * maxWalkSpeed;
         float acceleration = Mathf.Abs(joystick.x) > 0 ? walkAccelerationRate : groundDecelerationRate;
 
@@ -84,7 +88,7 @@ public class ControllableUnit : PhysicsUnit
                 slopeDirection = rightMostSlopeAngle > 0.0f ? rightMostSlopeDirection : -leftMostSlopeDirection;
             }
 
-            Vector2 projectedVelocity = Vector3.Project(joystick.normalized, slopeDirection) * joystick.magnitude;
+            Vector2 projectedVelocity = Vector3.Project(velocity, slopeDirection);
 
             velocity.x = GetNewVelocity(projectedVelocity.x, walkSpeed * slopeDirection.x, acceleration * slopeDirection.x);
             velocity.y = GetNewVelocity(projectedVelocity.y, walkSpeed * slopeDirection.y, acceleration * slopeDirection.y);

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -29,6 +29,7 @@ public class ControllableUnit : PhysicsUnit
     public int maxDoubleJumpCount = 1;
     protected int doubleJumpLeft;
     public bool canJumpChangeDirection = true;
+    public float minSlopeJumpAngle = 15.0f;
 
     // Events
     public UnityEvent onJumpEvent = new UnityEvent();
@@ -158,14 +159,31 @@ public class ControllableUnit : PhysicsUnit
 
     private void Jump(float jumpHeight)
     {
+        Vector2 jumpVelocity = new Vector2(canJumpChangeDirection ? joystick.x * maxAirSpeed : velocity.x, Mathf.Sqrt(2.0f * gravity * jumpHeight));
+        float jumpAngle = Vector2.Angle(Vector2.right, jumpVelocity);
+
+        // Make sure jump velocity is away from the grounds
+        if (180 - jumpAngle < leftMostSlopeAngle + minSlopeJumpAngle)
+        {
+            float rotateAngle = Mathf.Deg2Rad * -((leftMostSlopeAngle - (180 - jumpAngle)) + minSlopeJumpAngle);
+            float cos = Mathf.Cos(rotateAngle);
+            float sin = Mathf.Sin(rotateAngle);
+
+            jumpVelocity.x = jumpVelocity.x * cos - jumpVelocity.y * sin;
+        }
+        else if (jumpAngle < rightMostSlopeAngle + minSlopeJumpAngle)
+        {
+            float rotateAngle = Mathf.Deg2Rad * (rightMostSlopeAngle - jumpAngle + minSlopeJumpAngle);
+            float cos = Mathf.Cos(rotateAngle);
+            float sin = Mathf.Sin(rotateAngle);
+
+            jumpVelocity.x = jumpVelocity.x * cos - jumpVelocity.y * sin;
+        }
+
+        velocity = jumpVelocity;
         isJumpSquatting = false;
         isJumping = true;
         _isGrounded = false;
-        if (canJumpChangeDirection)
-        {
-            velocity.x = joystick.x * maxAirSpeed;
-        }
-        velocity.y = Mathf.Sqrt(2.0f * gravity * jumpHeight);
         onJumpEvent.Invoke();
     }
 

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -111,6 +111,15 @@ public class ControllableUnit : PhysicsUnit
         }
     }
 
+    protected override void ApplySlopeGravity()
+    {
+        if (isOnSlope && canWalkOnSlope)
+        {
+            return;
+        }
+        base.ApplySlopeGravity();
+    }
+
     protected virtual void ApplyJumpMovement()
     {
         switch (jumpEventType)
@@ -262,6 +271,4 @@ public class ControllableUnit : PhysicsUnit
         isInputEnabled = false;
         joystick = Vector2.zero;
     }
-
-
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -14,6 +14,7 @@ public class ControllableUnit : PhysicsUnit
     public float maxWalkSpeed = 5.0f;
     public float walkAccelerationRate = 15.0f;
     public float groundDecelerationRate = 20.0f;
+    private Vector2 slopeStickPosition;
 
     // Air Movement Variables
     public float maxAirSpeed = 3.0f;
@@ -44,6 +45,7 @@ public class ControllableUnit : PhysicsUnit
     {
         ApplyControls();
         base.Tick();
+        StickToSlope();
     }
 
     private void ApplyControls()
@@ -185,6 +187,35 @@ public class ControllableUnit : PhysicsUnit
         isJumping = true;
         _isGrounded = false;
         onJumpEvent.Invoke();
+    }
+
+    private void StickToSlope()
+    {
+        if (isJumping)
+        {
+            return;
+        }
+        Vector2 feetPos = unitRigidbody.position + velocity * Time.fixedDeltaTime - Vector2.up * (capsule.size.y - capsule.size.x) / 2 + capsule.offset;
+        RaycastHit2D hit = Physics2D.CircleCast(feetPos, capsule.size.x / 2, Vector2.down, velocity.magnitude, groundLayerMask);
+
+        if (hit)
+        {
+            slopeStickPosition = hit.point + hit.normal.normalized * capsule.size.x / 2;
+
+            float diff = slopeStickPosition.y - feetPos.y;
+
+            Debug.DrawLine(feetPos, slopeStickPosition, Color.white);
+            unitRigidbody.MovePosition(unitRigidbody.position + velocity * Time.fixedDeltaTime + Vector2.up * diff);
+        }
+    }
+
+    void OnDrawGizmosSelected()
+    {
+        if (capsule != null)
+        {
+            UnityEditor.Handles.color = Color.green;
+            UnityEditor.Handles.DrawWireDisc(slopeStickPosition, Vector3.forward, capsule.size.x / 2);
+        }
     }
 
     protected override void OnLand()

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -5,6 +5,7 @@ using UnityEngine.Events;
 
 public class PhysicsUnit : BaseUnit
 {
+    private CapsuleCollider2D capsule;
     public Transform feetPosition;
     public float groundCheckRadius;
     public LayerMask groundLayerMask;
@@ -16,8 +17,31 @@ public class PhysicsUnit : BaseUnit
     [SerializeField]
     private bool _isGrounded;
 
+    // Slope movement Variables
+    public bool isOnSlope = false;
+    public float leftMostSlopeAngle = 0.0f;
+    public float rightMostSlopeAngle = 0.0f;
+    public Vector2 leftMostSlopeDirection;
+    public Vector2 rightMostSlopeDirection;
+
+    // Slope calculation variables
+    private List<Vector2> leftSideSlopes = new List<Vector2>();
+    private List<Vector2> rightSideSlopes = new List<Vector2>();
+    private List<Vector2> centerSlopes = new List<Vector2>();
+
+    // Collision variables
+    private ContactPoint2D[] contactPoints = new ContactPoint2D[10];
+    protected List<ContactPoint2D> groundContactPoints = new List<ContactPoint2D>();
+    protected float groundContactCount;
+
     // Events
     public UnityEvent onLandEvent = new UnityEvent();
+
+    protected override void Start()
+    {
+        capsule = GetComponent<CapsuleCollider2D>();
+        base.Start();
+    }
 
     protected override void FixedUpdate()
     {
@@ -27,18 +51,66 @@ public class PhysicsUnit : BaseUnit
 
     protected void UpdatePhysics()
     {
+        CheckSlope();
         CheckGround();
         ApplyGravity();
     }
 
-    private void CheckGround()
+    private void CheckSlope()
     {
-        if (velocity.y > 0)
+        // Sort Contact Points based on slope angle
+        // Slopes with angle '\' are on the left, angle '/' are on the right, angle '--' are at the center
+        foreach (ContactPoint2D contactPoint in groundContactPoints)
         {
-            _isGrounded = false;
-            return;
+            Vector2 point = contactPoint.point;
+            Vector2 normal = contactPoint.normal;
+            Vector2 slopeDirection = -Vector2.Perpendicular(normal).normalized;
+            float slopeAngle = -Vector2.SignedAngle(normal, Vector2.up);
+
+            if (slopeAngle < -float.Epsilon)
+            {
+                leftSideSlopes.Add(-slopeDirection);
+                Debug.DrawRay(point, -slopeDirection, Color.red);
+            }
+            else if (slopeAngle > float.Epsilon)
+            {
+                rightSideSlopes.Add(slopeDirection);
+                Debug.DrawRay(point, slopeDirection, Color.blue);
+            }
+            else
+            {
+                centerSlopes.Add(slopeDirection);
+                Debug.DrawRay(point, slopeDirection, Color.green);
+            }
         }
 
+        // Get the steepest slope angle on the left and right
+        leftSideSlopes.Sort(SortBySlopeAngle);
+        rightSideSlopes.Sort(SortBySlopeAngle);
+        leftMostSlopeDirection = leftSideSlopes.Count > 0 ? leftSideSlopes[0] : Vector2.zero;
+        rightMostSlopeDirection = rightSideSlopes.Count > 0 ? rightSideSlopes[rightSideSlopes.Count - 1] : Vector2.zero;
+        leftMostSlopeAngle = Vector2.Angle(leftMostSlopeDirection, Vector2.left);
+        rightMostSlopeAngle = Vector2.Angle(rightMostSlopeDirection, Vector2.right);
+        isOnSlope = centerSlopes.Count <= 0;
+
+        // Clear variables
+        leftSideSlopes.Clear();
+        rightSideSlopes.Clear();
+        centerSlopes.Clear();
+        groundContactPoints.Clear();
+        groundContactCount = 0;
+    }
+
+    static int SortBySlopeAngle(Vector2 direction1, Vector2 direction2)
+    {
+        float angle1 = Vector2.SignedAngle(direction1, Vector2.right);
+        float angle2 = Vector2.SignedAngle(direction2, Vector2.right);
+
+        return angle1.CompareTo(angle2);
+    }
+
+    protected virtual void CheckGround()
+    {
         bool isOnGround = Physics2D.OverlapCircle(feetPosition.position, groundCheckRadius, groundLayerMask);
 
         if (!isGrounded && isOnGround)
@@ -51,22 +123,38 @@ public class PhysicsUnit : BaseUnit
 
     protected virtual void OnLand()
     {
-        velocity.y = 0;
         onLandEvent.Invoke();
     }
 
-    private void ApplyGravity()
+    protected void ApplyGravity()
     {
         if (!isGrounded)
         {
             velocity.y = GetNewVelocity(velocity.y, -maxFallSpeed, gravity);
+        }
+        else if (isOnSlope)
+        {
+            if (leftMostSlopeAngle > 0.0f)
+            {
+                velocity.x = GetNewVelocity(velocity.x, -maxFallSpeed * leftMostSlopeDirection.x, gravity * leftMostSlopeDirection.x);
+                velocity.y = GetNewVelocity(velocity.y, -maxFallSpeed * leftMostSlopeDirection.y, gravity * leftMostSlopeDirection.y);
+            }
+            else if (rightMostSlopeAngle > 0.0f)
+            {
+                velocity.x = GetNewVelocity(velocity.x, -maxFallSpeed * rightMostSlopeDirection.x, gravity * rightMostSlopeDirection.x);
+                velocity.y = GetNewVelocity(velocity.y, -maxFallSpeed * rightMostSlopeDirection.y, gravity * rightMostSlopeDirection.y);
+            }
+        }
+        else
+        {
+            velocity.y = 0.0f;
         }
     }
 
     protected float GetNewVelocity(float currentVelocity, float targetVelocity, float accelerationRate)
     {
         int direction = currentVelocity > targetVelocity ? -1 : 1;
-        float acceleration = accelerationRate * Time.fixedDeltaTime;
+        float acceleration = Mathf.Abs(accelerationRate * Time.fixedDeltaTime);
         float newVelocity = currentVelocity + acceleration * direction;
         float velocityDifference = Mathf.Abs(currentVelocity - targetVelocity);
 
@@ -76,5 +164,26 @@ public class PhysicsUnit : BaseUnit
         }
 
         return newVelocity;
+    }
+
+    protected virtual void OnCollisionStay2D(Collision2D collision)
+    {
+        if (collision.collider.gameObject.layer == LayerMask.NameToLayer("Ground"))
+        {
+            float feetThreshold = unitRigidbody.position.y - (capsule.size.y - capsule.size.x) / 2;
+            float count = collision.GetContacts(contactPoints);
+
+            for (int i = 0; i < count; i++)
+            {
+                ContactPoint2D contact = contactPoints[i];
+
+                if (contact.point.y > feetThreshold)
+                {
+                    continue;
+                }
+                groundContactPoints.Add(contactPoints[i]);
+                groundContactCount++;
+            }
+        }
     }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -210,7 +210,8 @@ public class PhysicsUnit : BaseUnit
 
     protected virtual void HandleGroundCollision(Collision2D collision)
     {
-        float feetThreshold = unitRigidbody.position.y - (capsule.size.y - capsule.size.x) / 2;
+        float feetThreshold = unitRigidbody.position.y - (capsule.size.y - capsule.size.x) / 2 + capsule.offset.y;
+        Vector2 feetPos = prevPosition - Vector2.up * (capsule.size.y - capsule.size.x) / 2 + capsule.offset;
         float count = collision.GetContacts(contactPoints);
 
         for (int i = 0; i < count; i++)

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -5,7 +5,7 @@ using UnityEngine.Events;
 
 public class PhysicsUnit : BaseUnit
 {
-    private CapsuleCollider2D capsule;
+    protected CapsuleCollider2D capsule;
     public Transform feetPosition;
     public float groundCheckRadius;
     public LayerMask groundLayerMask;
@@ -217,7 +217,7 @@ public class PhysicsUnit : BaseUnit
         {
             ContactPoint2D contact = contactPoints[i];
 
-            if (contact.point.y > feetThreshold)
+            if (contact.point.y >= feetPos.y)
             {
                 continue;
             }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -15,7 +15,7 @@ public class PhysicsUnit : BaseUnit
 
     public bool isGrounded { get { return _isGrounded; } }
     [SerializeField]
-    private bool _isGrounded;
+    protected bool _isGrounded;
 
     // Slope movement Variables
     public bool isOnSlope = false;

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -191,26 +191,31 @@ public class PhysicsUnit : BaseUnit
         }
         else if (isOnSlope)
         {
-            Vector2 slopeDirection;
-
-            if (velocity.x < 0.0f)
-            {
-                slopeDirection = leftMostSlopeAngle > 0.0f ? leftMostSlopeDirection : rightMostSlopeDirection;
-            }
-            else
-            {
-                slopeDirection = rightMostSlopeAngle > 0.0f ? rightMostSlopeDirection : leftMostSlopeDirection;
-            }
-
-            Vector2 projectedVelocity = Vector3.Project(velocity, slopeDirection);
-
-            velocity.x = GetNewVelocity(projectedVelocity.x, -maxFallSpeed * slopeDirection.x, gravity * slopeDirection.x);
-            velocity.y = GetNewVelocity(projectedVelocity.y, -maxFallSpeed * slopeDirection.y, gravity * slopeDirection.y);
+            ApplySlopeGravity();
         }
         else
         {
             velocity.y = 0.0f;
         }
+    }
+
+    protected virtual void ApplySlopeGravity()
+    {
+        Vector2 slopeDirection;
+
+        if (velocity.x < 0.0f)
+        {
+            slopeDirection = leftMostSlopeAngle > 0.0f ? leftMostSlopeDirection : rightMostSlopeDirection;
+        }
+        else
+        {
+            slopeDirection = rightMostSlopeAngle > 0.0f ? rightMostSlopeDirection : leftMostSlopeDirection;
+        }
+
+        Vector2 projectedVelocity = Vector3.Project(velocity, slopeDirection);
+
+        velocity.x = GetNewVelocity(projectedVelocity.x, -maxFallSpeed * slopeDirection.x, gravity * slopeDirection.x);
+        velocity.y = GetNewVelocity(projectedVelocity.y, -maxFallSpeed * slopeDirection.y, gravity * slopeDirection.y);
     }
 
     protected float GetNewVelocity(float currentVelocity, float targetVelocity, float accelerationRate)

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -86,7 +86,7 @@ public class FighterController : MonoBehaviour
 
     public void Land()
     {
-        playerInput.SwitchCurrentActionMap("Grounded");
+        // playerInput.SwitchCurrentActionMap("Grounded");
         Debug.Log("Landed");
     }
 

--- a/Runelight-Smash-2021/ProjectSettings/Physics2DSettings.asset
+++ b/Runelight-Smash-2021/ProjectSettings/Physics2DSettings.asset
@@ -5,7 +5,7 @@ Physics2DSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 5
   m_Gravity: {x: 0, y: 0}
-  m_DefaultMaterial: {fileID: 0}
+  m_DefaultMaterial: {fileID: 6200000, guid: 5b075c48d34681248ab9e4aadaeb0e7f, type: 2}
   m_VelocityIterations: 8
   m_PositionIterations: 3
   m_VelocityThreshold: 1


### PR DESCRIPTION
## 이슈 번호
* #2 

## 작업 내역
* 기본 경사면 이동 구현:

![slope_demo](https://user-images.githubusercontent.com/16410221/127776225-e2e15829-3265-4f66-bb0f-d5f560e92034.gif)

* 경사면을 따라 붙어다니며 이동하는 기능을 PhysicsUnit 과 ControllableUnit 에 추가
  * 걷는 속도 벡터가 경사면 각도에 맞춰서 적용
  * 최대 경사면 각도를 지정하면 그 이상의 경사면에서는 착지하지 않고 미끄러져 내려감

## 리뷰받고 싶은 Point
* 현재 맞닿아 있는 경사면을 OnCollisionStay2D의 ContactPoint 들로 가져오고 다음 프레임의 FixedUpdate 에서 정렬하여 계산하는 방식인데, 더 좋은 방법은 없을지 검토 필요
  * StickToSlope() 을 구현할 때 썼던 Physics2D.CircleCast 를 사용하는 방향은 어떨지 추후 검토 필요
