### PR TITLE
경사면 감지 로직 변경 및 버그 수정

### DIFF
--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -491,13 +491,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 506207282}
-  m_LocalRotation: {x: -0, y: -0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 11.176325, y: 0.69080126, z: 9.427856}
+  m_LocalRotation: {x: -0, y: -0, z: 0.7885492, w: 0.61497164}
+  m_LocalPosition: {x: 10.71, y: 0.67, z: 9.427856}
   m_LocalScale: {x: 2, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1457690516}
   m_RootOrder: 11
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 104.1}
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -1373,11 +1373,11 @@ PolygonCollider2D:
       - {x: -5, y: 2}
       - {x: -7, y: 2}
       - {x: -7, y: 4}
-      - {x: -8, y: 4}
+      - {x: -17, y: 4}
       - {x: -8, y: -5}
       - {x: 12, y: -5}
-      - {x: 12, y: 3}
-      - {x: 11, y: 3}
+      - {x: 22, y: 3}
+      - {x: 10, y: 3}
       - {x: 11, y: -1}
 --- !u!4 &1457690516
 Transform:
@@ -1473,7 +1473,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2025968840}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -11.91, y: 5.44, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 519420032}
@@ -1986,13 +1986,13 @@ MonoBehaviour:
   leftMostSlopeDirection: {x: 0, y: 0}
   rightMostSlopeDirection: {x: 0, y: 0}
   canWalkOnSlope: 0
-  maxSlopeAngle: 45
+  maxSlopeAngle: 80
   onLandEvent:
     m_PersistentCalls:
       m_Calls: []
-  maxWalkSpeed: 4
-  walkAccelerationRate: 15
-  groundDecelerationRate: 20
+  maxWalkSpeed: 30
+  walkAccelerationRate: 100
+  groundDecelerationRate: 2
   maxAirSpeed: 3
   airAccelerationRate: 8
   airDecelerationRate: 10

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1941,7 +1941,7 @@ Rigidbody2D:
   m_Material: {fileID: 0}
   m_Interpolate: 0
   m_SleepingMode: 1
-  m_CollisionDetection: 0
+  m_CollisionDetection: 1
   m_Constraints: 4
 --- !u!70 &2025968850
 CapsuleCollider2D:

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1980,7 +1980,6 @@ MonoBehaviour:
   gravity: 20
   maxFallSpeed: 5
   isGrounded: 0
-  _isGrounded: 0
   isOnSlope: 0
   leftMostSlopeAngle: 0
   rightMostSlopeAngle: 0

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1982,15 +1982,17 @@ MonoBehaviour:
   isGrounded: 0
   isOnSlope: 0
   leftMostSlopeAngle: 0
+  centerSlopeAngle: 0
   rightMostSlopeAngle: 0
   leftMostSlopeDirection: {x: 0, y: 0}
+  centerSlopeDirection: {x: 0, y: 0}
   rightMostSlopeDirection: {x: 0, y: 0}
   canWalkOnSlope: 0
-  maxSlopeAngle: 80
+  maxSlopeAngle: 45
   onLandEvent:
     m_PersistentCalls:
       m_Calls: []
-  maxWalkSpeed: 30
+  maxWalkSpeed: 15
   walkAccelerationRate: 100
   groundDecelerationRate: 2
   maxAirSpeed: 3

--- a/Runelight-Smash-2021/Assets/Scripts/Character/BaseUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/BaseUnit.cs
@@ -33,7 +33,7 @@ public class BaseUnit : MonoBehaviour
         }
     }
 
-    private void ApplyVelocity()
+    protected virtual void ApplyVelocity()
     {
         prevPosition = unitRigidbody.position;
         unitRigidbody.MovePosition(unitRigidbody.position + velocity * Time.fixedDeltaTime);

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -56,7 +56,7 @@ public class ControllableUnit : PhysicsUnit
 
     private void ApplyMovement()
     {
-        if (_isGrounded)
+        if (isGrounded)
         {
             ApplyGroundMovement();
         }
@@ -208,16 +208,17 @@ public class ControllableUnit : PhysicsUnit
         {
             return;
         }
-        Vector2 feetPos = unitRigidbody.position + velocity * Time.fixedDeltaTime - Vector2.up * (capsule.size.y - capsule.size.x) / 2 + capsule.offset;
-        RaycastHit2D hit = Physics2D.CircleCast(feetPos, capsule.size.x / 2, Vector2.down, velocity.magnitude, groundLayerMask);
+        Vector2 centerPos = unitRigidbody.position + velocity * Time.fixedDeltaTime + capsule.offset;
+        float distance = (capsule.size.y - capsule.size.x) / 2;
+        RaycastHit2D hit = Physics2D.CircleCast(centerPos, capsule.size.x / 2, Vector2.down, velocity.magnitude, groundLayerMask);
 
         if (hit)
         {
-            slopeStickPosition = hit.point + hit.normal.normalized * capsule.size.x / 2;
+            slopeStickPosition = hit.centroid;
 
-            float diff = slopeStickPosition.y - feetPos.y;
+            float diff = slopeStickPosition.y - centerPos.y + distance;
 
-            Debug.DrawLine(feetPos, slopeStickPosition, Color.white);
+            Debug.DrawLine(centerPos, slopeStickPosition, Color.white);
             unitRigidbody.MovePosition(unitRigidbody.position + velocity * Time.fixedDeltaTime + Vector2.up * diff);
         }
     }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -128,21 +128,21 @@ public class ControllableUnit : PhysicsUnit
                 isJumpSquatting = true;
                 break;
             case JumpEventType.ShortHop:
-                if (!_isGrounded)
+                if (!isGrounded)
                 {
                     break;
                 }
                 ShortHop();
                 break;
             case JumpEventType.FullHop:
-                if (!_isGrounded)
+                if (!isGrounded)
                 {
                     break;
                 }
                 FullHop();
                 break;
             case JumpEventType.DoubleJump:
-                if (_isGrounded)
+                if (isGrounded)
                 {
                     break;
                 }
@@ -198,7 +198,7 @@ public class ControllableUnit : PhysicsUnit
         velocity = jumpVelocity;
         isJumpSquatting = false;
         isJumping = true;
-        _isGrounded = false;
+        isGrounded = false;
         onJumpEvent.Invoke();
     }
 
@@ -237,11 +237,6 @@ public class ControllableUnit : PhysicsUnit
         doubleJumpLeft = maxDoubleJumpCount;
         isJumping = false;
         base.OnLand();
-    }
-
-    protected override bool IsPhysicallyGrounded()
-    {
-        return isJumping ? false : base.IsPhysicallyGrounded();
     }
 
     public void SetJoystickInput(Vector2 input)

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -204,7 +204,7 @@ public class ControllableUnit : PhysicsUnit
 
     private void StickToSlope()
     {
-        if (isJumping)
+        if (isJumping || !isGrounded)
         {
             return;
         }
@@ -214,12 +214,26 @@ public class ControllableUnit : PhysicsUnit
 
         if (hit)
         {
+            Vector2 perpendicular = Vector2.Perpendicular(hit.normal);
+            Vector2 nextSlopeDirection = perpendicular.x > 0.0f ? perpendicular : -perpendicular;
+            float nextSlopeAngle = Vector2.Angle(perpendicular, Vector2.left);
+
+            if (nextSlopeAngle > maxSlopeAngle)
+            {
+                return;
+            }
+            Ray2D ray1 = new Ray2D(unitRigidbody.position + capsule.offset - Vector2.up * ((capsule.size.y - capsule.size.x) / 2 + Physics2D.defaultContactOffset), velocity * Time.fixedDeltaTime);
+            Ray2D ray2 = new Ray2D(hit.centroid, velocity.x < 0.0f ? nextSlopeDirection : -nextSlopeDirection);
+
+            if (!Math2D.IsRayIntersecting(ray1, ray2))
+            {
+                return;
+            }
+
             slopeStickPosition = hit.centroid;
 
-            float diff = slopeStickPosition.y - centerPos.y + distance;
-
-            Debug.DrawLine(centerPos, slopeStickPosition, Color.white);
-            unitRigidbody.MovePosition(unitRigidbody.position + velocity * Time.fixedDeltaTime + Vector2.up * diff);
+            Debug.DrawLine(unitRigidbody.position, slopeStickPosition + Vector2.up * (distance - capsule.offset.y), Color.white);
+            unitRigidbody.position = (slopeStickPosition + Vector2.up * (distance - capsule.offset.y));
         }
     }
 

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -15,8 +15,6 @@ public class PhysicsUnit : BaseUnit
 
     [SerializeField]
     public bool isGrounded;
-    [SerializeField]
-    protected bool _isGrounded;
 
     // Slope movement Variables
     public bool isOnSlope = false;
@@ -180,28 +178,18 @@ public class PhysicsUnit : BaseUnit
         return true;
     }
 
-    protected virtual bool IsUnitGrounded()
-    {
-        bool isOnGround = Physics2D.OverlapCircle(feetPosition.position, groundCheckRadius, groundLayerMask);
-        bool isbetweenSlopes = leftMostSlopeAngle > 0.0f && rightMostSlopeAngle > 0.0f;
-
-        return isOnGround && (canWalkOnSlope || isbetweenSlopes);
-    }
-
     private void CheckGround()
     {
-        bool _isOnGround = IsPhysicallyGrounded();
-        bool isOnGround = IsUnitGrounded();
+        bool isOnGround = IsPhysicallyGrounded();
 
         if (!isGrounded && isOnGround)
         {
             OnLand();
         }
 
-        _isGrounded = _isOnGround;
         isGrounded = isOnGround;
 
-        if (!_isGrounded)
+        if (!isGrounded)
         {
             isOnSlope = false;
             canWalkOnSlope = false;
@@ -220,7 +208,7 @@ public class PhysicsUnit : BaseUnit
 
     protected void ApplyGravity()
     {
-        if (!_isGrounded)
+        if (!isGrounded)
         {
             velocity.y = GetNewVelocity(velocity.y, -maxFallSpeed, gravity);
         }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -28,14 +28,13 @@ public class PhysicsUnit : BaseUnit
     public float maxSlopeAngle = 45.0f;
 
     // Slope calculation variables
-    private List<Vector2> leftSideSlopes = new List<Vector2>();
-    private List<Vector2> rightSideSlopes = new List<Vector2>();
-    private List<Vector2> centerSlopes = new List<Vector2>();
+    private List<Vector2> slopes = new List<Vector2>();
+    private ContactFilter2D filter = new ContactFilter2D();
+    private float CAST_OFFSET = 0.05f;
 
     // Collision variables
     private ContactPoint2D[] contactPoints = new ContactPoint2D[10];
-    protected List<ContactPoint2D> groundContactPoints = new List<ContactPoint2D>();
-    protected float groundContactCount;
+    private RaycastHit2D[] hits = new RaycastHit2D[10];
 
     // Events
     public UnityEvent onLandEvent = new UnityEvent();
@@ -43,6 +42,7 @@ public class PhysicsUnit : BaseUnit
     protected override void Start()
     {
         capsule = GetComponent<CapsuleCollider2D>();
+        filter.SetLayerMask(groundLayerMask);
         base.Start();
     }
 
@@ -75,44 +75,13 @@ public class PhysicsUnit : BaseUnit
 
     private void CheckSlope()
     {
-        if (groundContactCount <= 0)
+        GetSlopeCollisionPoints();
+
+        if (slopes.Count <= 0)
         {
             return;
         }
-        // Sort Contact Points based on slope angle
-        // Slopes with angle '\' are on the left, angle '/' are on the right, angle '--' are at the center
-        foreach (ContactPoint2D contactPoint in groundContactPoints)
-        {
-            Vector2 point = contactPoint.point;
-            Vector2 normal = contactPoint.normal;
-            Vector2 slopeDirection = -Vector2.Perpendicular(normal).normalized;
-            float slopeAngle = -Vector2.SignedAngle(normal, Vector2.up);
-
-            if (slopeAngle < -float.Epsilon)
-            {
-                leftSideSlopes.Add(-slopeDirection);
-                Debug.DrawRay(point, -slopeDirection, Color.red);
-            }
-            else if (slopeAngle > float.Epsilon)
-            {
-                rightSideSlopes.Add(slopeDirection);
-                Debug.DrawRay(point, slopeDirection, Color.blue);
-            }
-            else
-            {
-                centerSlopes.Add(slopeDirection);
-                Debug.DrawRay(point, slopeDirection, Color.green);
-            }
-        }
-
-        // Get the steepest slope angle on the left and right
-        leftSideSlopes.Sort(SortBySlopeAngle);
-        rightSideSlopes.Sort(SortBySlopeAngle);
-        leftMostSlopeDirection = leftSideSlopes.Count > 0 ? leftSideSlopes[0] : Vector2.zero;
-        rightMostSlopeDirection = rightSideSlopes.Count > 0 ? rightSideSlopes[rightSideSlopes.Count - 1] : Vector2.zero;
-        leftMostSlopeAngle = Vector2.Angle(leftMostSlopeDirection, Vector2.left);
-        rightMostSlopeAngle = Vector2.Angle(rightMostSlopeDirection, Vector2.right);
-        isOnSlope = leftMostSlopeAngle > 0.0f || rightMostSlopeAngle > 0.0f;
+        CalculateSlopes();
 
         float currentSlope = 0.0f;
 
@@ -128,17 +97,82 @@ public class PhysicsUnit : BaseUnit
         canWalkOnSlope = currentSlope <= maxSlopeAngle;
     }
 
-    static int SortBySlopeAngle(Vector2 direction1, Vector2 direction2)
+    private void GetSlopeCollisionPoints()
     {
-        float angle1 = Vector2.SignedAngle(direction1, Vector2.right);
-        float angle2 = Vector2.SignedAngle(direction2, Vector2.right);
+        Vector2 centerPos = unitRigidbody.position + capsule.offset;
+        Vector2 feetPos = centerPos - Vector2.up * (capsule.size.y - capsule.size.x) / 2;
+        float distance = (centerPos - feetPos).y;
+        int count = Physics2D.CircleCast(centerPos, capsule.size.x / 2, Vector2.down, filter, hits, distance + CAST_OFFSET);
+
+        for (int i = 0; i < count; i++)
+        {
+            RaycastHit2D hit = hits[i];
+
+            if (hit.point.y >= centerPos.y - distance)
+            {
+                continue;
+            }
+
+            Vector2 slopeDirection = AddToSlopes(hit);
+
+            // CircleCast returns only one collision per object, so perform CircleCast again to get more collision points
+            RaycastHit2D extraHit = Physics2D.CircleCast(feetPos, capsule.size.x / 2, slopeDirection.y < 0.0f ? slopeDirection : -slopeDirection, CAST_OFFSET, groundLayerMask);
+            if (extraHit)
+            {
+                AddToSlopes(extraHit);
+            }
+        }
+    }
+
+    private Vector2 AddToSlopes(RaycastHit2D hit)
+    {
+        Vector2 normal = hit.normal;
+        Vector2 slopeDirection = -Vector2.Perpendicular(normal).normalized;
+        float slopeAngle = -Vector2.SignedAngle(normal, Vector2.up);
+
+        slopes.Add(normal);
+        Debug.DrawRay(hit.point, slopeDirection.y < 0.0f ? -slopeDirection : slopeDirection, Color.red);
+
+        return slopeDirection;
+    }
+
+    private void CalculateSlopes()
+    {
+        if (slopes.Count <= 0)
+        {
+            leftMostSlopeDirection = Vector2.zero;
+            rightMostSlopeDirection = Vector2.zero;
+            leftMostSlopeAngle = 0.0f;
+            rightMostSlopeAngle = 0.0f;
+            return;
+        }
+
+        slopes.Sort(SortBySlopeAngle);
+
+        // Get the steepest slope angle on the left and right
+        Vector2 leftMost = -Vector2.Perpendicular(slopes[0]);
+        Vector2 rightMost = -Vector2.Perpendicular(slopes[slopes.Count - 1]);
+        float left = Vector2.SignedAngle(Vector2.right, leftMost);
+        float right = Vector2.SignedAngle(Vector2.right, rightMost);
+
+        leftMostSlopeDirection = left < 0.0f ? -leftMost : Vector2.zero;
+        rightMostSlopeDirection = right > 0.0f ? rightMost : Vector2.zero;
+        leftMostSlopeAngle = Vector2.SignedAngle(leftMostSlopeDirection, Vector2.left);
+        rightMostSlopeAngle = -Vector2.SignedAngle(rightMostSlopeDirection, Vector2.right);
+        isOnSlope = leftMostSlopeAngle > 0.0f || rightMostSlopeAngle > 0.0f;
+    }
+
+    static int SortBySlopeAngle(Vector2 normal1, Vector2 normal2)
+    {
+        float angle1 = -Vector2.SignedAngle(normal1, Vector2.up);
+        float angle2 = -Vector2.SignedAngle(normal2, Vector2.up);
 
         return angle1.CompareTo(angle2);
     }
 
     protected virtual bool IsPhysicallyGrounded()
     {
-        if (groundContactCount <= 0)
+        if (slopes.Count <= 0)
         {
             return false;
         }
@@ -167,15 +201,16 @@ public class PhysicsUnit : BaseUnit
         _isGrounded = _isOnGround;
         isGrounded = isOnGround;
 
+        if (!_isGrounded)
+        {
+            isOnSlope = false;
+            canWalkOnSlope = false;
+        }
     }
 
     private void ClearCollisionVariables()
     {
-        leftSideSlopes.Clear();
-        rightSideSlopes.Clear();
-        centerSlopes.Clear();
-        groundContactPoints.Clear();
-        groundContactCount = 0;
+        slopes.Clear();
     }
 
     protected virtual void OnLand()
@@ -231,32 +266,5 @@ public class PhysicsUnit : BaseUnit
         }
 
         return newVelocity;
-    }
-
-    protected virtual void OnCollisionStay2D(Collision2D collision)
-    {
-        if (collision.collider.gameObject.layer == LayerMask.NameToLayer("Ground"))
-        {
-            HandleGroundCollision(collision);
-        }
-    }
-
-    protected virtual void HandleGroundCollision(Collision2D collision)
-    {
-        float feetThreshold = unitRigidbody.position.y - (capsule.size.y - capsule.size.x) / 2 + capsule.offset.y;
-        Vector2 feetPos = prevPosition - Vector2.up * (capsule.size.y - capsule.size.x) / 2 + capsule.offset;
-        float count = collision.GetContacts(contactPoints);
-
-        for (int i = 0; i < count; i++)
-        {
-            ContactPoint2D contact = contactPoints[i];
-
-            if (contact.point.y >= feetPos.y)
-            {
-                continue;
-            }
-            groundContactPoints.Add(contactPoints[i]);
-            groundContactCount++;
-        }
     }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -28,7 +28,7 @@ public class PhysicsUnit : BaseUnit
     // Slope calculation variables
     private List<Vector2> slopes = new List<Vector2>();
     private ContactFilter2D filter = new ContactFilter2D();
-    private float CAST_OFFSET = 0.05f;
+    protected float CAST_OFFSET = 0.05f;
 
     // Collision variables
     private ContactPoint2D[] contactPoints = new ContactPoint2D[10];
@@ -208,7 +208,7 @@ public class PhysicsUnit : BaseUnit
 
     protected void ApplyGravity()
     {
-        if (!isGrounded)
+        if (!isGrounded || !canWalkOnSlope)
         {
             velocity.y = GetNewVelocity(velocity.y, -maxFallSpeed, gravity);
         }

--- a/Runelight-Smash-2021/Assets/Scripts/Util.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Util.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f4ca83a1aec19440a2e8def20f63f27
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/Util/Math2D.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Util/Math2D.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public static class Math2D
+{
+    private static float EPSILON = 0.05f;
+
+    public static bool IsRayIntersecting(Ray2D ray1, Ray2D ray2)
+    {
+        Debug.DrawLine(ray1.origin, ray1.origin + ray1.direction, Color.green);
+        Debug.DrawLine(ray2.origin, ray2.origin + ray2.direction, Color.blue);
+
+        float dx = ray2.origin.x - ray1.origin.x;
+        float dy = ray2.origin.y - ray1.origin.y;
+        float det = ray2.direction.x * ray1.direction.y - ray2.direction.y * ray1.direction.x;
+
+        if (det == 0.0f)
+        {
+            Vector2 diff = ray2.origin - ray1.origin;
+
+            return Mathf.Abs(ray1.direction.x * diff.y - ray1.direction.y * diff.x) < EPSILON;
+        }
+        float u = (dy * ray2.direction.x - dx * ray2.direction.y) / det;
+        float v = (dy * ray1.direction.x - dx * ray1.direction.y) / det;
+        u = Mathf.Abs(u) < EPSILON ? EPSILON : u;
+        v = Mathf.Abs(v) < EPSILON ? EPSILON : v;
+
+        return u * v >= 0.0f;
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/Util/Math2D.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Util/Math2D.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a810ebeafc05acc47a2509037c3d4cb1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/ProjectSettings/Physics2DSettings.asset
+++ b/Runelight-Smash-2021/ProjectSettings/Physics2DSettings.asset
@@ -40,7 +40,7 @@ Physics2DSettings:
     m_IslandSolverContactsPerJob: 50
   m_SimulationMode: 0
   m_QueriesHitTriggers: 1
-  m_QueriesStartInColliders: 0
+  m_QueriesStartInColliders: 1
   m_CallbacksOnDisable: 1
   m_ReuseCollisionCallbacks: 1
   m_AutoSyncTransforms: 0

--- a/Runelight-Smash-2021/ProjectSettings/Physics2DSettings.asset
+++ b/Runelight-Smash-2021/ProjectSettings/Physics2DSettings.asset
@@ -18,7 +18,7 @@ Physics2DSettings:
   m_TimeToSleep: 0.5
   m_LinearSleepTolerance: 0.01
   m_AngularSleepTolerance: 2
-  m_DefaultContactOffset: 0.01
+  m_DefaultContactOffset: 0.0001
   m_JobOptions:
     serializedVersion: 2
     useMultithreading: 0
@@ -40,7 +40,7 @@ Physics2DSettings:
     m_IslandSolverContactsPerJob: 50
   m_SimulationMode: 0
   m_QueriesHitTriggers: 1
-  m_QueriesStartInColliders: 1
+  m_QueriesStartInColliders: 0
   m_CallbacksOnDisable: 1
   m_ReuseCollisionCallbacks: 1
   m_AutoSyncTransforms: 0


### PR DESCRIPTION
## 이슈 번호
* #2 

## 작업 내역

![slope_demo](https://user-images.githubusercontent.com/16410221/128868339-52a65206-bfc9-4081-a6e8-fd0453178bc5.gif)

* 경사면 감지 로직을 `OnCollisionStay()` 에서 `Physics.CircleCast`로 변경
  * `OnCollisionStay()` 는 1프레임 전의 contact 상황을 알려줘서 부정확함
  * 이에 따라 `Physics.CircleCast()`를 두번하는 방법으로 변경
    * 한번은 직각 아래로
    * 또 한번은 부딪힌 경사면에 평행하게
  * 두번 하는 이유는 `Physics.CirclaCast`가 `Collider` 당 한개의 `RaycastHit2D` 만 반환하기 때문에, 두 경사면 사이에 끼어있는 경우에 두번째 경사면도 구하기 위해서
* `isGrounded` 체크 로직을 경사면 체크 로직으로 통일
  * 경사면 체크와 동일하게 CircleCast 로 땅에 붙어있는지 체크할 수 있으므로
* 경사면에 달라붙는 로직이 난간에선 작동하지 않도록 수정
  * `StickToSlope()` 가 난간에서 작동해서 1프레임만에 슉 떨어져서 붙어버리는 이슈가 있음
  * 이를 해결하기 위해 다음과 같은 알고리즘 작성:
    *  `StickToSlope()` 로 붙을 땅으로 CircleCast를 하면, 해당 지점의 경사면 방향의 Ray 와 현재 위치의 velocity 방향의 Ray 가 서로 교차하는지 확인
    * 교차하면, 붙을 수 있는 경사면
    * 교차하지 않으면, 난간이므로 붙으면 안됨
* 캐릭터가 올라갈 수 있는 결사면보다 높은 경사면은 벽으로 취급하여 부딪히도록 구현
  * 실제 움직이고 있는 경사면인 `centerSlope` 정의
  * `leftMostSlope` 과 `rightMostSlope` 은 이제 벽에 부딪혔는지 확인하는 용도

## 리뷰받고 싶은 Point
* N/A
