### PR TITLE
구현된 이동 기능들을 Entity-Component 구조로 리팩토링

### DIFF
--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1442,6 +1442,7 @@ GameObject:
   - component: {fileID: 2025968847}
   - component: {fileID: 2025968848}
   - component: {fileID: 2025968852}
+  - component: {fileID: 2025968853}
   - component: {fileID: 2025968845}
   - component: {fileID: 2025968850}
   - component: {fileID: 2025968849}
@@ -1987,11 +1988,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7f45e4acb7a8cee4eb91fe97d8476438, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  gravity: 20
-  maxFallSpeed: 5
-  onLandEvent:
-    m_PersistentCalls:
-      m_Calls: []
   maxWalkSpeed: 5
   walkAccelerationRate: 20
   groundDecelerationRate: 40
@@ -2025,3 +2021,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   velocity: {x: 0, y: 0}
+--- !u!114 &2025968853
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f9e9612b8d04245a0d869ad9f55c1b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  gravity: 20
+  maxFallSpeed: 5

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1441,6 +1441,7 @@ GameObject:
   - component: {fileID: 2025968846}
   - component: {fileID: 2025968847}
   - component: {fileID: 2025968854}
+  - component: {fileID: 2025968855}
   - component: {fileID: 2025968848}
   - component: {fileID: 2025968852}
   - component: {fileID: 2025968853}
@@ -1989,9 +1990,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7f45e4acb7a8cee4eb91fe97d8476438, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxWalkSpeed: 5
-  walkAccelerationRate: 20
-  groundDecelerationRate: 40
   maxAirSpeed: 3
   airAccelerationRate: 8
   airDecelerationRate: 10
@@ -2004,11 +2002,6 @@ MonoBehaviour:
   onJumpEvent:
     m_PersistentCalls:
       m_Calls: []
-  isDashing: 0
-  isDashStarted: 0
-  initialDashSpeed: 5
-  dashAccelerationRate: 40
-  maxDashSpeed: 10
 --- !u!114 &2025968852
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2049,3 +2042,23 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   joystick: {x: 0, y: 0}
+--- !u!114 &2025968855
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d73a4b183b76d7a438da8d332bbc668f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxWalkSpeed: 5
+  walkAccelerationRate: 15
+  groundDecelerationRate: 40
+  initialDashSpeed: 6
+  dashAccelerationRate: 40
+  maxDashSpeed: 12
+  isDashing: 0
+  isDashStarted: 0

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1444,6 +1444,7 @@ GameObject:
   - component: {fileID: 2025968855}
   - component: {fileID: 2025968856}
   - component: {fileID: 2025968857}
+  - component: {fileID: 2025968858}
   - component: {fileID: 2025968848}
   - component: {fileID: 2025968852}
   - component: {fileID: 2025968853}
@@ -2090,3 +2091,15 @@ MonoBehaviour:
   onJumpEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &2025968858
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e153cf66ff3d1347ba1503e05e9ee71, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1440,6 +1440,7 @@ GameObject:
   - component: {fileID: 2025968844}
   - component: {fileID: 2025968846}
   - component: {fileID: 2025968847}
+  - component: {fileID: 2025968854}
   - component: {fileID: 2025968848}
   - component: {fileID: 2025968852}
   - component: {fileID: 2025968853}
@@ -2035,3 +2036,16 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gravity: 20
   maxFallSpeed: 5
+--- !u!114 &2025968854
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2a6eb7800b90f184d9bf7d8dacc6ca8a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  joystick: {x: 0, y: 0}

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1443,6 +1443,7 @@ GameObject:
   - component: {fileID: 2025968854}
   - component: {fileID: 2025968855}
   - component: {fileID: 2025968856}
+  - component: {fileID: 2025968857}
   - component: {fileID: 2025968848}
   - component: {fileID: 2025968852}
   - component: {fileID: 2025968853}
@@ -1991,15 +1992,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7f45e4acb7a8cee4eb91fe97d8476438, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  shortHopHeight: 1.5
-  fullHopHeight: 3
-  doubleJumpHeight: 3
-  maxDoubleJumpCount: 1
-  canJumpChangeDirection: 1
-  minSlopeJumpAngle: 30
-  onJumpEvent:
-    m_PersistentCalls:
-      m_Calls: []
 --- !u!114 &2025968852
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2075,3 +2067,26 @@ MonoBehaviour:
   maxAirSpeed: 3
   airAccelerationRate: 8
   airDecelerationRate: 10
+--- !u!114 &2025968857
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b62cf03d15c02c8418d2d840bf853d55, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  shortHopHeight: 1.5
+  fullHopHeight: 3
+  doubleJumpHeight: 3
+  maxDoubleJumpCount: 1
+  canJumpChangeDirection: 1
+  minSlopeJumpAngle: 15
+  isJumpSquatting: 0
+  isJumping: 0
+  onJumpEvent:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1441,6 +1441,8 @@ GameObject:
   - component: {fileID: 2025968846}
   - component: {fileID: 2025968847}
   - component: {fileID: 2025968848}
+  - component: {fileID: 2025968852}
+  - component: {fileID: 2025968845}
   - component: {fileID: 2025968850}
   - component: {fileID: 2025968849}
   - component: {fileID: 2025968851}
@@ -1871,6 +1873,34 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c4cb1090aa47ead459d86f0210e82e4a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &2025968845
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c3c6a524bab19044c91693cb39279ea4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  groundLayerMask:
+    serializedVersion: 2
+    m_Bits: 64
+  maxSlopeAngle: 45
+  isGrounded: 0
+  isOnSlope: 0
+  leftMostSlopeAngle: 0
+  centerSlopeAngle: 0
+  rightMostSlopeAngle: 0
+  leftMostSlopeDirection: {x: 0, y: 0}
+  centerSlopeDirection: {x: 0, y: 0}
+  rightMostSlopeDirection: {x: 0, y: 0}
+  canWalkOnSlope: 0
+  onLandEvent:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &2025968846
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1957,24 +1987,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7f45e4acb7a8cee4eb91fe97d8476438, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  velocity: {x: 0, y: 0}
-  feetPosition: {fileID: 442199920}
-  groundCheckRadius: 0.2
-  groundLayerMask:
-    serializedVersion: 2
-    m_Bits: 64
   gravity: 20
   maxFallSpeed: 5
-  isGrounded: 0
-  isOnSlope: 0
-  leftMostSlopeAngle: 0
-  centerSlopeAngle: 0
-  rightMostSlopeAngle: 0
-  leftMostSlopeDirection: {x: 0, y: 0}
-  centerSlopeDirection: {x: 0, y: 0}
-  rightMostSlopeDirection: {x: 0, y: 0}
-  canWalkOnSlope: 0
-  maxSlopeAngle: 45
   onLandEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -1998,3 +2012,16 @@ MonoBehaviour:
   initialDashSpeed: 5
   dashAccelerationRate: 40
   maxDashSpeed: 10
+--- !u!114 &2025968852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c809f4e2f671eb4c893c3cbbe443e51, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  velocity: {x: 0, y: 0}

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -1442,6 +1442,7 @@ GameObject:
   - component: {fileID: 2025968847}
   - component: {fileID: 2025968854}
   - component: {fileID: 2025968855}
+  - component: {fileID: 2025968856}
   - component: {fileID: 2025968848}
   - component: {fileID: 2025968852}
   - component: {fileID: 2025968853}
@@ -1990,9 +1991,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7f45e4acb7a8cee4eb91fe97d8476438, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxAirSpeed: 3
-  airAccelerationRate: 8
-  airDecelerationRate: 10
   shortHopHeight: 1.5
   fullHopHeight: 3
   doubleJumpHeight: 3
@@ -2062,3 +2060,18 @@ MonoBehaviour:
   maxDashSpeed: 12
   isDashing: 0
   isDashStarted: 0
+--- !u!114 &2025968856
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025968840}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c6cd50f2eb5934649aed9398016f5dc4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxAirSpeed: 3
+  airAccelerationRate: 8
+  airDecelerationRate: 10

--- a/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
+++ b/Runelight-Smash-2021/Assets/Scenes/SampleScene.unity
@@ -2085,7 +2085,7 @@ MonoBehaviour:
   doubleJumpHeight: 3
   maxDoubleJumpCount: 1
   canJumpChangeDirection: 1
-  minSlopeJumpAngle: 15
+  minSlopeJumpAngle: 30
   isJumpSquatting: 0
   isJumping: 0
   onJumpEvent:

--- a/Runelight-Smash-2021/Assets/Scripts/ActionHandler/FighterActionHandler.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/ActionHandler/FighterActionHandler.cs
@@ -22,18 +22,18 @@ public class FighterActionHandler : MonoBehaviour
 
     // TODO: Decouple FighterActionHandler from FighterController
     private FighterController fighterController;
-    private FighterUnit fighterUnit;
+    private SlopeComponent slopeComponent;
 
     // Start is called before the first frame update
     void Start()
     {
         fighterController = GetComponent<FighterController>();
-        fighterUnit = GetComponent<FighterUnit>();
+        slopeComponent = GetComponent<SlopeComponent>();
     }
 
     public void HandleJump(InputAction.CallbackContext input)
     {
-        if (!fighterUnit.isGrounded)
+        if (!slopeComponent.isGrounded)
         {
             if (input.started)
             {

--- a/Runelight-Smash-2021/Assets/Scripts/Character/BaseUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/BaseUnit.cs
@@ -4,20 +4,14 @@ using UnityEngine;
 
 public class BaseUnit : MonoBehaviour
 {
-    protected Collider2D unitCollider;
     protected Rigidbody2D unitRigidbody;
-    protected Vector2 prevPosition;
-
-    [SerializeField]
-    protected Vector2 velocity;
-    protected bool isMovementEnabled { get { return _isMovementEnabled; } }
-    private bool _isMovementEnabled = true;
+    protected VelocityComponent velocityComponent;
 
     // Start is called before the first frame update
     protected virtual void Start()
     {
-        unitCollider = GetComponent<Collider2D>();
         unitRigidbody = GetComponent<Rigidbody2D>();
+        velocityComponent = GetComponent<VelocityComponent>();
     }
 
     protected virtual void FixedUpdate()
@@ -25,31 +19,5 @@ public class BaseUnit : MonoBehaviour
         Tick();
     }
 
-    protected virtual void Tick()
-    {
-        if (isMovementEnabled)
-        {
-            ApplyVelocity();
-        }
-    }
-
-    protected virtual void ApplyVelocity()
-    {
-        prevPosition = unitRigidbody.position;
-        unitRigidbody.MovePosition(unitRigidbody.position + velocity * Time.fixedDeltaTime);
-    }
-
-    protected void DisableMovement()
-    {
-        _isMovementEnabled = false;
-        unitRigidbody.velocity = Vector2.zero;
-        unitRigidbody.isKinematic = true;
-    }
-
-    protected void EnableMovement()
-    {
-        _isMovementEnabled = true;
-        unitRigidbody.velocity = Vector2.zero;
-        unitRigidbody.isKinematic = false;
-    }
+    protected virtual void Tick() { }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/BaseUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/BaseUnit.cs
@@ -2,22 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(Rigidbody2D))]
+[RequireComponent(typeof(VelocityComponent))]
+
 public class BaseUnit : MonoBehaviour
 {
-    protected Rigidbody2D unitRigidbody;
-    protected VelocityComponent velocityComponent;
 
-    // Start is called before the first frame update
-    protected virtual void Start()
-    {
-        unitRigidbody = GetComponent<Rigidbody2D>();
-        velocityComponent = GetComponent<VelocityComponent>();
-    }
-
-    protected virtual void FixedUpdate()
-    {
-        Tick();
-    }
-
-    protected virtual void Tick() { }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -87,12 +87,12 @@ public class ControllableUnit : PhysicsUnit
             Vector2 slopeDirection = Mathf.Sign(slopeComponent.centerSlopeDirection.x) * slopeComponent.centerSlopeDirection;
             Vector2 projectedVelocity = Vector3.Project(velocityComponent.velocity, slopeDirection);
 
-            velocityComponent.velocity.x = GetNewVelocity(projectedVelocity.x, speed * slopeDirection.x, acceleration * slopeDirection.x);
-            velocityComponent.velocity.y = GetNewVelocity(projectedVelocity.y, speed * slopeDirection.y, acceleration * slopeDirection.y);
+            velocityComponent.velocity.x = Velocity.GetNewVelocity(projectedVelocity.x, speed * slopeDirection.x, acceleration * slopeDirection.x);
+            velocityComponent.velocity.y = Velocity.GetNewVelocity(projectedVelocity.y, speed * slopeDirection.y, acceleration * slopeDirection.y);
         }
         else
         {
-            velocityComponent.velocity.x = GetNewVelocity(velocityComponent.velocity.x, speed, acceleration);
+            velocityComponent.velocity.x = Velocity.GetNewVelocity(velocityComponent.velocity.x, speed, acceleration);
         }
 
         if (velocityComponent.velocity.x < 0.0f && slopeComponent.leftMostSlopeAngle > slopeComponent.maxSlopeAngle)
@@ -111,11 +111,11 @@ public class ControllableUnit : PhysicsUnit
     {
         if (Mathf.Abs(joystick.x) > 0)
         {
-            velocityComponent.velocity.x = GetNewVelocity(velocityComponent.velocity.x, joystick.x * maxAirSpeed, airAccelerationRate);
+            velocityComponent.velocity.x = Velocity.GetNewVelocity(velocityComponent.velocity.x, joystick.x * maxAirSpeed, airAccelerationRate);
         }
         else
         {
-            velocityComponent.velocity.x = GetNewVelocity(velocityComponent.velocity.x, 0.0f, airDecelerationRate);
+            velocityComponent.velocity.x = Velocity.GetNewVelocity(velocityComponent.velocity.x, 0.0f, airDecelerationRate);
         }
     }
 

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -13,89 +13,15 @@ public class ControllableUnit : PhysicsUnit
     // Input Variables
     protected bool isInputEnabled = true;
 
-    private Vector2 slopeStickPosition;
-
     protected override void Start()
     {
         base.Start();
         capsule = GetComponent<CapsuleCollider2D>();
-        joystickComponent = GetComponent<JoystickComponent>();
-        airMovementComponent = GetComponent<AirMovementComponent>();
-        jumpComponent = GetComponent<JumpComponent>();
     }
 
     protected override void Tick()
     {
         base.Tick();
-        StickToSlope();
-    }
-
-    private void StickToSlope()
-    {
-        if (jumpComponent.isJumping || !slopeComponent.isGrounded || !slopeComponent.canWalkOnSlope)
-        {
-            return;
-        }
-        RaycastHit2D hit;
-        float distanceToFeetPos = (capsule.size.y - capsule.size.x) / 2;
-        float radius = capsule.size.x / 2;
-        Vector2 centerPos = unitRigidbody.position + capsule.offset;
-        Vector2 feetPos = centerPos - Vector2.up * distanceToFeetPos;
-        Vector2 nextVelocityStep = velocityComponent.velocity * Time.fixedDeltaTime;
-        Vector2 nextPos = centerPos + nextVelocityStep;
-
-        hit = Physics2D.CircleCast(feetPos, radius, nextVelocityStep, nextVelocityStep.magnitude, slopeComponent.groundLayerMask);
-
-        if (hit)
-        {
-            float nextSlopeAngle = Slope.GetSlopeAngle(hit.normal);
-
-            if (nextSlopeAngle > slopeComponent.maxSlopeAngle)
-            {
-                slopeStickPosition = hit.centroid;
-                Vector2 newSlopeStickPosition = slopeStickPosition + Vector2.up * (distanceToFeetPos - capsule.offset.y);
-
-                Debug.DrawLine(unitRigidbody.position, newSlopeStickPosition, Color.white);
-                velocityComponent.ForceToPosition(newSlopeStickPosition);
-                return;
-            }
-        }
-
-        hit = Physics2D.CircleCast(nextPos, radius, Vector2.down, velocityComponent.velocity.magnitude, slopeComponent.groundLayerMask);
-
-        if (hit)
-        {
-            Vector2 perpendicular = Vector2.Perpendicular(hit.normal);
-            Vector2 nextSlopeDirection = perpendicular.x > 0.0f ? perpendicular : -perpendicular;
-            float nextSlopeAngle = Vector2.Angle(perpendicular, Vector2.left);
-
-            if (nextSlopeAngle > slopeComponent.maxSlopeAngle)
-            {
-                return;
-            }
-            Ray2D ray1 = new Ray2D(feetPos - Vector2.up * Physics2D.defaultContactOffset, nextVelocityStep);
-            Ray2D ray2 = new Ray2D(hit.centroid, velocityComponent.velocity.x < 0.0f ? nextSlopeDirection : -nextSlopeDirection);
-
-            if (!Math2D.IsRayIntersecting(ray1, ray2))
-            {
-                return;
-            }
-
-            slopeStickPosition = hit.centroid;
-            Vector2 newSlopeStickPosition = slopeStickPosition + Vector2.up * (distanceToFeetPos - capsule.offset.y);
-
-            Debug.DrawLine(unitRigidbody.position, newSlopeStickPosition, Color.white);
-            velocityComponent.ForceToPosition(newSlopeStickPosition);
-        }
-    }
-
-    void OnDrawGizmosSelected()
-    {
-        if (capsule != null)
-        {
-            UnityEditor.Handles.color = Color.green;
-            UnityEditor.Handles.DrawWireDisc(slopeStickPosition, Vector3.forward, capsule.size.x / 2);
-        }
     }
 
     public void EnableInput()

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -8,6 +8,7 @@ public class ControllableUnit : PhysicsUnit
     // Required Components
     protected CapsuleCollider2D capsule;
     protected JoystickComponent joystickComponent;
+    protected AirMovementComponent airMovementComponent;
 
     // Input Variables
     protected bool isInputEnabled = true;
@@ -15,11 +16,6 @@ public class ControllableUnit : PhysicsUnit
     protected JumpEventType jumpEventType = JumpEventType.None;
 
     private Vector2 slopeStickPosition;
-
-    // Air Movement Variables
-    public float maxAirSpeed = 3.0f;
-    public float airAccelerationRate = 8.0f;
-    public float airDecelerationRate = 10.0f;
 
     // Jump Variables
     protected bool isJumpSquatting;
@@ -40,6 +36,7 @@ public class ControllableUnit : PhysicsUnit
         base.Start();
         capsule = GetComponent<CapsuleCollider2D>();
         joystickComponent = GetComponent<JoystickComponent>();
+        airMovementComponent = GetComponent<AirMovementComponent>();
         doubleJumpLeft = maxDoubleJumpCount;
         slopeComponent.onLandEvent.AddListener(OnLand);
     }
@@ -53,32 +50,7 @@ public class ControllableUnit : PhysicsUnit
 
     private void ApplyControls()
     {
-        ApplyMovement();
         ApplyJumpMovement();
-    }
-
-    private void ApplyMovement()
-    {
-        if (slopeComponent.isGrounded)
-        {
-
-        }
-        else
-        {
-            ApplyAirMovement();
-        }
-    }
-
-    protected virtual void ApplyAirMovement()
-    {
-        if (Mathf.Abs(joystickComponent.joystick.x) > 0)
-        {
-            velocityComponent.velocity.x = Velocity.GetNewVelocity(velocityComponent.velocity.x, joystickComponent.joystick.x * maxAirSpeed, airAccelerationRate);
-        }
-        else
-        {
-            velocityComponent.velocity.x = Velocity.GetNewVelocity(velocityComponent.velocity.x, 0.0f, airDecelerationRate);
-        }
     }
 
     protected virtual void ApplyJumpMovement()
@@ -135,7 +107,7 @@ public class ControllableUnit : PhysicsUnit
 
     private void Jump(float jumpHeight)
     {
-        float targetJumpSpeed = joystickComponent.joystick.x > 0 ? Mathf.Max(joystickComponent.joystick.x * maxAirSpeed, velocityComponent.velocity.x) : Mathf.Min(joystickComponent.joystick.x * maxAirSpeed, velocityComponent.velocity.x);
+        float targetJumpSpeed = joystickComponent.joystick.x > 0 ? Mathf.Max(joystickComponent.joystick.x * airMovementComponent.maxAirSpeed, velocityComponent.velocity.x) : Mathf.Min(joystickComponent.joystick.x * airMovementComponent.maxAirSpeed, velocityComponent.velocity.x);
         float jumpSpeed = canJumpChangeDirection ? targetJumpSpeed : velocityComponent.velocity.x;
         Vector2 jumpVelocity = new Vector2(jumpSpeed, Mathf.Sqrt(2.0f * gravityComponent.gravity * jumpHeight));
         float jumpAngle = Vector2.Angle(Vector2.right, jumpVelocity);

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -119,15 +119,6 @@ public class ControllableUnit : PhysicsUnit
         }
     }
 
-    protected override void ApplySlopeGravity()
-    {
-        if (slopeComponent.isOnSlope && slopeComponent.canWalkOnSlope)
-        {
-            return;
-        }
-        base.ApplySlopeGravity();
-    }
-
     protected virtual void ApplyJumpMovement()
     {
         switch (jumpEventType)
@@ -184,7 +175,7 @@ public class ControllableUnit : PhysicsUnit
     {
         float targetJumpSpeed = joystick.x > 0 ? Mathf.Max(joystick.x * maxAirSpeed, velocityComponent.velocity.x) : Mathf.Min(joystick.x * maxAirSpeed, velocityComponent.velocity.x);
         float jumpSpeed = canJumpChangeDirection ? targetJumpSpeed : velocityComponent.velocity.x;
-        Vector2 jumpVelocity = new Vector2(jumpSpeed, Mathf.Sqrt(2.0f * gravity * jumpHeight));
+        Vector2 jumpVelocity = new Vector2(jumpSpeed, Mathf.Sqrt(2.0f * gravityComponent.gravity * jumpHeight));
         float jumpAngle = Vector2.Angle(Vector2.right, jumpVelocity);
         float slopeAngle = Mathf.Sign(velocityComponent.velocity.y) * slopeComponent.centerSlopeAngle;
 

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -14,12 +14,6 @@ public class ControllableUnit : PhysicsUnit
 
     protected JumpEventType jumpEventType = JumpEventType.None;
 
-    // Ground Movement Variables
-    protected virtual float groundSpeed { get { return Mathf.Abs(joystickComponent.joystick.x) * maxWalkSpeed; } }
-    protected virtual float groundAccelerationRate { get { return walkAccelerationRate; } }
-    public float maxWalkSpeed = 5.0f;
-    public float walkAccelerationRate = 15.0f;
-    public float groundDecelerationRate = 20.0f;
     private Vector2 slopeStickPosition;
 
     // Air Movement Variables
@@ -67,45 +61,11 @@ public class ControllableUnit : PhysicsUnit
     {
         if (slopeComponent.isGrounded)
         {
-            ApplyGroundMovement();
+
         }
         else
         {
             ApplyAirMovement();
-        }
-    }
-
-    protected virtual void ApplyGroundMovement()
-    {
-        if (!slopeComponent.canWalkOnSlope)
-        {
-            return;
-        }
-        float speed = Mathf.Sign(joystickComponent.joystick.x) * groundSpeed;
-        float acceleration = Mathf.Abs(joystickComponent.joystick.x) > 0 ? groundAccelerationRate : groundDecelerationRate;
-
-        if (slopeComponent.isOnSlope)
-        {
-            Vector2 slopeDirection = Mathf.Sign(slopeComponent.centerSlopeDirection.x) * slopeComponent.centerSlopeDirection;
-            Vector2 projectedVelocity = Vector3.Project(velocityComponent.velocity, slopeDirection);
-
-            velocityComponent.velocity.x = Velocity.GetNewVelocity(projectedVelocity.x, speed * slopeDirection.x, acceleration * slopeDirection.x);
-            velocityComponent.velocity.y = Velocity.GetNewVelocity(projectedVelocity.y, speed * slopeDirection.y, acceleration * slopeDirection.y);
-        }
-        else
-        {
-            velocityComponent.velocity.x = Velocity.GetNewVelocity(velocityComponent.velocity.x, speed, acceleration);
-        }
-
-        if (velocityComponent.velocity.x < 0.0f && slopeComponent.leftMostSlopeAngle > slopeComponent.maxSlopeAngle)
-        {
-            velocityComponent.velocity = Vector2.zero;
-            return;
-        }
-        else if (velocityComponent.velocity.x > 0.0f && slopeComponent.rightMostSlopeAngle > slopeComponent.maxSlopeAngle)
-        {
-            velocityComponent.velocity = Vector2.zero;
-            return;
         }
     }
 

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -7,14 +7,15 @@ public class ControllableUnit : PhysicsUnit
 {
     // Required Components
     protected CapsuleCollider2D capsule;
+    protected JoystickComponent joystickComponent;
 
     // Input Variables
     protected bool isInputEnabled = true;
-    protected Vector2 joystick;
+
     protected JumpEventType jumpEventType = JumpEventType.None;
 
     // Ground Movement Variables
-    protected virtual float groundSpeed { get { return Mathf.Abs(joystick.x) * maxWalkSpeed; } }
+    protected virtual float groundSpeed { get { return Mathf.Abs(joystickComponent.joystick.x) * maxWalkSpeed; } }
     protected virtual float groundAccelerationRate { get { return walkAccelerationRate; } }
     public float maxWalkSpeed = 5.0f;
     public float walkAccelerationRate = 15.0f;
@@ -44,6 +45,7 @@ public class ControllableUnit : PhysicsUnit
     {
         base.Start();
         capsule = GetComponent<CapsuleCollider2D>();
+        joystickComponent = GetComponent<JoystickComponent>();
         doubleJumpLeft = maxDoubleJumpCount;
         slopeComponent.onLandEvent.AddListener(OnLand);
     }
@@ -79,8 +81,8 @@ public class ControllableUnit : PhysicsUnit
         {
             return;
         }
-        float speed = Mathf.Sign(joystick.x) * groundSpeed;
-        float acceleration = Mathf.Abs(joystick.x) > 0 ? groundAccelerationRate : groundDecelerationRate;
+        float speed = Mathf.Sign(joystickComponent.joystick.x) * groundSpeed;
+        float acceleration = Mathf.Abs(joystickComponent.joystick.x) > 0 ? groundAccelerationRate : groundDecelerationRate;
 
         if (slopeComponent.isOnSlope)
         {
@@ -109,9 +111,9 @@ public class ControllableUnit : PhysicsUnit
 
     protected virtual void ApplyAirMovement()
     {
-        if (Mathf.Abs(joystick.x) > 0)
+        if (Mathf.Abs(joystickComponent.joystick.x) > 0)
         {
-            velocityComponent.velocity.x = Velocity.GetNewVelocity(velocityComponent.velocity.x, joystick.x * maxAirSpeed, airAccelerationRate);
+            velocityComponent.velocity.x = Velocity.GetNewVelocity(velocityComponent.velocity.x, joystickComponent.joystick.x * maxAirSpeed, airAccelerationRate);
         }
         else
         {
@@ -173,7 +175,7 @@ public class ControllableUnit : PhysicsUnit
 
     private void Jump(float jumpHeight)
     {
-        float targetJumpSpeed = joystick.x > 0 ? Mathf.Max(joystick.x * maxAirSpeed, velocityComponent.velocity.x) : Mathf.Min(joystick.x * maxAirSpeed, velocityComponent.velocity.x);
+        float targetJumpSpeed = joystickComponent.joystick.x > 0 ? Mathf.Max(joystickComponent.joystick.x * maxAirSpeed, velocityComponent.velocity.x) : Mathf.Min(joystickComponent.joystick.x * maxAirSpeed, velocityComponent.velocity.x);
         float jumpSpeed = canJumpChangeDirection ? targetJumpSpeed : velocityComponent.velocity.x;
         Vector2 jumpVelocity = new Vector2(jumpSpeed, Mathf.Sqrt(2.0f * gravityComponent.gravity * jumpHeight));
         float jumpAngle = Vector2.Angle(Vector2.right, jumpVelocity);
@@ -278,14 +280,7 @@ public class ControllableUnit : PhysicsUnit
         isJumping = false;
     }
 
-    public void SetJoystickInput(Vector2 input)
-    {
-        if (!isInputEnabled)
-        {
-            return;
-        }
-        joystick = input;
-    }
+
 
     public void SetJumpInput(JumpEventType input)
     {
@@ -304,6 +299,6 @@ public class ControllableUnit : PhysicsUnit
     public void DisableInput()
     {
         isInputEnabled = false;
-        joystick = Vector2.zero;
+        joystickComponent.joystick = Vector2.zero;
     }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -236,7 +236,7 @@ public class ControllableUnit : PhysicsUnit
 
         if (hit)
         {
-            float nextSlopeAngle = slopeComponent.GetSlopeAngle(hit.normal);
+            float nextSlopeAngle = Slope.GetSlopeAngle(hit.normal);
 
             if (nextSlopeAngle > slopeComponent.maxSlopeAngle)
             {

--- a/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/ControllableUnit.cs
@@ -2,36 +2,18 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class ControllableUnit : PhysicsUnit
+[RequireComponent(typeof(CapsuleCollider2D))]
+[RequireComponent(typeof(Rigidbody2D))]
+[RequireComponent(typeof(AirMovementComponent))]
+[RequireComponent(typeof(GravityComponent))]
+[RequireComponent(typeof(GroundMovementComponent))]
+[RequireComponent(typeof(JoystickComponent))]
+[RequireComponent(typeof(JumpComponent))]
+[RequireComponent(typeof(SlopeComponent))]
+[RequireComponent(typeof(SlopeStickComponent))]
+[RequireComponent(typeof(VelocityComponent))]
+
+public class ControllableUnit : MonoBehaviour
 {
-    // Required Components
-    protected CapsuleCollider2D capsule;
-    protected JoystickComponent joystickComponent;
-    protected AirMovementComponent airMovementComponent;
-    protected JumpComponent jumpComponent;
 
-    // Input Variables
-    protected bool isInputEnabled = true;
-
-    protected override void Start()
-    {
-        base.Start();
-        capsule = GetComponent<CapsuleCollider2D>();
-    }
-
-    protected override void Tick()
-    {
-        base.Tick();
-    }
-
-    public void EnableInput()
-    {
-        isInputEnabled = true;
-    }
-
-    public void DisableInput()
-    {
-        isInputEnabled = false;
-        joystickComponent.joystick = Vector2.zero;
-    }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/FighterUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/FighterUnit.cs
@@ -20,7 +20,7 @@ public class FighterUnit : ControllableUnit
         {
             Vector2 normalized = velocityComponent.velocity.normalized;
 
-            velocityComponent.velocity.x = initialDashSpeed * (joystick.x > 0 ? Mathf.Abs(normalized.x) : -Mathf.Abs(normalized.x));
+            velocityComponent.velocity.x = initialDashSpeed * (joystickComponent.joystick.x > 0 ? Mathf.Abs(normalized.x) : -Mathf.Abs(normalized.x));
             velocityComponent.velocity.y = initialDashSpeed * normalized.y;
 
             isDashStarted = true;

--- a/Runelight-Smash-2021/Assets/Scripts/Character/FighterUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/FighterUnit.cs
@@ -1,9 +1,19 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Events;
 
-public class FighterUnit : ControllableUnit
+[RequireComponent(typeof(CapsuleCollider2D))]
+[RequireComponent(typeof(Rigidbody2D))]
+[RequireComponent(typeof(AirMovementComponent))]
+[RequireComponent(typeof(GravityComponent))]
+[RequireComponent(typeof(GroundMovementComponent))]
+[RequireComponent(typeof(JoystickComponent))]
+[RequireComponent(typeof(JumpComponent))]
+[RequireComponent(typeof(SlopeComponent))]
+[RequireComponent(typeof(SlopeStickComponent))]
+[RequireComponent(typeof(VelocityComponent))]
+
+public class FighterUnit : MonoBehaviour
 {
 
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/FighterUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/FighterUnit.cs
@@ -18,10 +18,10 @@ public class FighterUnit : ControllableUnit
     {
         if (isDashing && !isDashStarted)
         {
-            Vector2 normalized = velocity.normalized;
+            Vector2 normalized = velocityComponent.velocity.normalized;
 
-            velocity.x = initialDashSpeed * (joystick.x > 0 ? Mathf.Abs(normalized.x) : -Mathf.Abs(normalized.x));
-            velocity.y = initialDashSpeed * normalized.y;
+            velocityComponent.velocity.x = initialDashSpeed * (joystick.x > 0 ? Mathf.Abs(normalized.x) : -Mathf.Abs(normalized.x));
+            velocityComponent.velocity.y = initialDashSpeed * normalized.y;
 
             isDashStarted = true;
         }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/FighterUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/FighterUnit.cs
@@ -5,55 +5,5 @@ using UnityEngine.Events;
 
 public class FighterUnit : ControllableUnit
 {
-    protected override float groundSpeed { get { return isDashing ? maxDashSpeed : base.groundSpeed; } }
-    protected override float groundAccelerationRate { get { return isDashing ? dashAccelerationRate : walkAccelerationRate; } }
-    // Dash 
-    public bool isDashing = false;
-    public bool isDashStarted = false;
-    public float initialDashSpeed = 6.0f;
-    public float dashAccelerationRate = 40.0f;
-    public float maxDashSpeed = 12.0f;
 
-    protected override void ApplyGroundMovement()
-    {
-        if (isDashing && !isDashStarted)
-        {
-            Vector2 normalized = velocityComponent.velocity.normalized;
-
-            velocityComponent.velocity.x = initialDashSpeed * (joystickComponent.joystick.x > 0 ? Mathf.Abs(normalized.x) : -Mathf.Abs(normalized.x));
-            velocityComponent.velocity.y = initialDashSpeed * normalized.y;
-
-            isDashStarted = true;
-        }
-        base.ApplyGroundMovement();
-    }
-
-    public void SetDashInput(float direction)
-    {
-        if (direction < 0)
-        {
-            if (!isDashing)
-            {
-                Debug.Log("Dash Left");
-            }
-            isDashing = true;
-        }
-        else if (direction > 0)
-        {
-            if (!isDashing)
-            {
-                Debug.Log("Dash Right");
-            }
-            isDashing = true;
-        }
-        else
-        {
-            if (isDashing)
-            {
-                Debug.Log("Stop");
-                isDashing = false;
-                isDashStarted = false;
-            }
-        }
-    }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -6,52 +6,13 @@ using UnityEngine.Events;
 public class PhysicsUnit : BaseUnit
 {
     // Required Components
+    protected GravityComponent gravityComponent;
     protected SlopeComponent slopeComponent;
-
-    public float gravity = 20.0f;
-    public float maxFallSpeed = 5.0f;
 
     protected override void Start()
     {
         base.Start();
+        gravityComponent = GetComponent<GravityComponent>();
         slopeComponent = GetComponent<SlopeComponent>();
     }
-
-    protected override void Tick()
-    {
-        UpdatePhysics();
-        base.Tick();
-    }
-
-    protected void UpdatePhysics()
-    {
-        ApplyGravity();
-    }
-
-    protected void ApplyGravity()
-    {
-        if (!slopeComponent.isGrounded || !slopeComponent.canWalkOnSlope)
-        {
-            velocityComponent.velocity.y = Velocity.GetNewVelocity(velocityComponent.velocity.y, -maxFallSpeed, gravity);
-        }
-        else if (slopeComponent.isOnSlope)
-        {
-            ApplySlopeGravity();
-        }
-        else
-        {
-            velocityComponent.velocity.y = 0.0f;
-        }
-    }
-
-    protected virtual void ApplySlopeGravity()
-    {
-        Vector2 slopeDirection = Mathf.Sign(slopeComponent.centerSlopeDirection.x) * slopeComponent.centerSlopeDirection;
-        Vector2 projectedVelocity = Vector3.Project(velocityComponent.velocity, slopeDirection);
-
-        velocityComponent.velocity.x = Velocity.GetNewVelocity(projectedVelocity.x, -maxFallSpeed * slopeDirection.x, gravity * slopeDirection.x);
-        velocityComponent.velocity.y = Velocity.GetNewVelocity(projectedVelocity.y, -maxFallSpeed * slopeDirection.y, gravity * slopeDirection.y);
-    }
-
-
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -1,18 +1,13 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Events;
 
-public class PhysicsUnit : BaseUnit
+[RequireComponent(typeof(Rigidbody2D))]
+[RequireComponent(typeof(GravityComponent))]
+[RequireComponent(typeof(SlopeComponent))]
+[RequireComponent(typeof(VelocityComponent))]
+
+public class PhysicsUnit : MonoBehaviour
 {
-    // Required Components
-    protected GravityComponent gravityComponent;
-    protected SlopeComponent slopeComponent;
 
-    protected override void Start()
-    {
-        base.Start();
-        gravityComponent = GetComponent<GravityComponent>();
-        slopeComponent = GetComponent<SlopeComponent>();
-    }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -11,18 +11,6 @@ public class PhysicsUnit : BaseUnit
     public float gravity = 20.0f;
     public float maxFallSpeed = 5.0f;
 
-    // Slope calculation variables
-    private List<Vector2> slopes = new List<Vector2>();
-    private ContactFilter2D filter = new ContactFilter2D();
-    protected float CAST_OFFSET = 0.1f;
-
-    // Collision variables
-    private ContactPoint2D[] contactPoints = new ContactPoint2D[10];
-    private RaycastHit2D[] hits = new RaycastHit2D[10];
-
-    // Events
-    public UnityEvent onLandEvent = new UnityEvent();
-
     protected override void Start()
     {
         base.Start();
@@ -44,7 +32,7 @@ public class PhysicsUnit : BaseUnit
     {
         if (!slopeComponent.isGrounded || !slopeComponent.canWalkOnSlope)
         {
-            velocity.y = GetNewVelocity(velocity.y, -maxFallSpeed, gravity);
+            velocityComponent.velocity.y = GetNewVelocity(velocityComponent.velocity.y, -maxFallSpeed, gravity);
         }
         else if (slopeComponent.isOnSlope)
         {
@@ -52,17 +40,17 @@ public class PhysicsUnit : BaseUnit
         }
         else
         {
-            velocity.y = 0.0f;
+            velocityComponent.velocity.y = 0.0f;
         }
     }
 
     protected virtual void ApplySlopeGravity()
     {
         Vector2 slopeDirection = Mathf.Sign(slopeComponent.centerSlopeDirection.x) * slopeComponent.centerSlopeDirection;
-        Vector2 projectedVelocity = Vector3.Project(velocity, slopeDirection);
+        Vector2 projectedVelocity = Vector3.Project(velocityComponent.velocity, slopeDirection);
 
-        velocity.x = GetNewVelocity(projectedVelocity.x, -maxFallSpeed * slopeDirection.x, gravity * slopeDirection.x);
-        velocity.y = GetNewVelocity(projectedVelocity.y, -maxFallSpeed * slopeDirection.y, gravity * slopeDirection.y);
+        velocityComponent.velocity.x = GetNewVelocity(projectedVelocity.x, -maxFallSpeed * slopeDirection.x, gravity * slopeDirection.x);
+        velocityComponent.velocity.y = GetNewVelocity(projectedVelocity.y, -maxFallSpeed * slopeDirection.y, gravity * slopeDirection.y);
     }
 
     protected float GetNewVelocity(float currentVelocity, float targetVelocity, float accelerationRate)

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -5,27 +5,11 @@ using UnityEngine.Events;
 
 public class PhysicsUnit : BaseUnit
 {
-    protected CapsuleCollider2D capsule;
-    public Transform feetPosition;
-    public float groundCheckRadius;
-    public LayerMask groundLayerMask;
+    // Required Components
+    protected SlopeComponent slopeComponent;
 
     public float gravity = 20.0f;
     public float maxFallSpeed = 5.0f;
-
-    [SerializeField]
-    public bool isGrounded;
-
-    // Slope movement Variables
-    public bool isOnSlope = false;
-    public float leftMostSlopeAngle = 0.0f;
-    public float centerSlopeAngle = 0.0f;
-    public float rightMostSlopeAngle = 0.0f;
-    public Vector2 leftMostSlopeDirection;
-    public Vector2 centerSlopeDirection;
-    public Vector2 rightMostSlopeDirection;
-    public bool canWalkOnSlope;
-    public float maxSlopeAngle = 45.0f;
 
     // Slope calculation variables
     private List<Vector2> slopes = new List<Vector2>();
@@ -41,15 +25,8 @@ public class PhysicsUnit : BaseUnit
 
     protected override void Start()
     {
-        capsule = GetComponent<CapsuleCollider2D>();
-        filter.SetLayerMask(groundLayerMask);
         base.Start();
-    }
-
-    protected override void FixedUpdate()
-    {
-        UpdateCollision();
-        base.FixedUpdate();
+        slopeComponent = GetComponent<SlopeComponent>();
     }
 
     protected override void Tick()
@@ -58,189 +35,18 @@ public class PhysicsUnit : BaseUnit
         base.Tick();
     }
 
-    protected void UpdateCollision()
-    {
-        if (!unitRigidbody.IsSleeping())
-        {
-            CheckSlope();
-            CheckGround();
-            ClearCollisionVariables();
-        }
-    }
-
     protected void UpdatePhysics()
     {
         ApplyGravity();
     }
 
-    private void CheckSlope()
-    {
-        GetSlopeCollisionPoints();
-
-        if (slopes.Count <= 0)
-        {
-            return;
-        }
-        CalculateSlopes();
-
-        canWalkOnSlope = centerSlopeAngle <= maxSlopeAngle;
-    }
-
-    private void GetSlopeCollisionPoints()
-    {
-        Vector2 centerPos = unitRigidbody.position + capsule.offset;
-        Vector2 feetPos = centerPos - Vector2.up * (capsule.size.y - capsule.size.x) / 2;
-        float distance = (centerPos - feetPos).y;
-        int count = Physics2D.CircleCast(centerPos, capsule.size.x / 2, Vector2.down, filter, hits, distance + CAST_OFFSET);
-
-        for (int i = 0; i < count; i++)
-        {
-            RaycastHit2D hit = hits[i];
-
-            if (hit.point.y >= centerPos.y - distance)
-            {
-                continue;
-            }
-
-            Vector2 slopeDirection = AddToSlopes(hit);
-
-            // CircleCast returns only one collision per object, so perform CircleCast again to get more collision points
-            RaycastHit2D extraHit = Physics2D.CircleCast(feetPos, capsule.size.x / 2, slopeDirection.y < 0.0f ? slopeDirection : -slopeDirection, CAST_OFFSET, groundLayerMask);
-            if (extraHit)
-            {
-                AddToSlopes(extraHit);
-            }
-        }
-    }
-
-    private Vector2 AddToSlopes(RaycastHit2D hit)
-    {
-        Vector2 normal = hit.normal;
-        Vector2 slopeDirection = GetSignedSlopeDirection(normal);
-
-        slopes.Add(normal);
-        Debug.DrawRay(hit.point, slopeDirection.y < 0.0f ? -slopeDirection : slopeDirection, Color.red);
-
-        return slopeDirection;
-    }
-
-    protected Vector2 GetSignedSlopeDirection(Vector2 normal)
-    {
-        return -Vector2.Perpendicular(normal).normalized;
-    }
-
-    protected Vector2 GetSlopeDirection(Vector2 normal)
-    {
-        Vector2 signedSlopeDirection = GetSignedSlopeDirection(normal);
-
-        return signedSlopeDirection.y < 0.0f ? -signedSlopeDirection : signedSlopeDirection;
-    }
-
-    protected float GetSignedSlopeAngle(Vector2 normal)
-    {
-        return -Vector2.SignedAngle(normal, Vector2.up);
-    }
-
-    protected float GetSlopeAngle(Vector2 normal)
-    {
-        float signedSlopeAngle = GetSignedSlopeAngle(normal);
-
-        return Mathf.Abs(signedSlopeAngle);
-    }
-
-    private void CalculateSlopes()
-    {
-        if (slopes.Count <= 0)
-        {
-            leftMostSlopeDirection = Vector2.zero;
-            rightMostSlopeDirection = Vector2.zero;
-            centerSlopeDirection = Vector2.zero;
-            leftMostSlopeAngle = 0.0f;
-            rightMostSlopeAngle = 0.0f;
-            centerSlopeAngle = 0.0f;
-            return;
-        }
-
-        slopes.Sort(SortBySlopeAngle);
-
-        // Get the steepest slope angle on the left and right
-        Vector2 leftMostNormal = slopes[0];
-        Vector2 rightMostNormal = slopes[slopes.Count - 1];
-        Vector2 centerNormal = Vector2.up;
-        Vector2 leftMost = GetSignedSlopeDirection(leftMostNormal);
-        Vector2 rightMost = GetSignedSlopeDirection(rightMostNormal);
-        float left = GetSignedSlopeAngle(leftMostNormal);
-        float right = GetSignedSlopeAngle(rightMostNormal);
-
-        if (left < 0.0f && right > 0.0f)
-        {
-            centerNormal = leftMostNormal + rightMostNormal;
-        }
-        else if (left < 0.0f)
-        {
-            centerNormal = rightMostNormal;
-        }
-        else if (right > 0.0f)
-        {
-            centerNormal = leftMostNormal;
-        }
-
-        leftMostSlopeDirection = left < 0.0f ? GetSlopeDirection(leftMostNormal) : Vector2.zero;
-        rightMostSlopeDirection = right > 0.0f ? GetSlopeDirection(rightMostNormal) : Vector2.zero;
-        leftMostSlopeAngle = Vector2.SignedAngle(leftMostSlopeDirection, Vector2.left);
-        rightMostSlopeAngle = -Vector2.SignedAngle(rightMostSlopeDirection, Vector2.right);
-        centerSlopeDirection = GetSlopeDirection(centerNormal);
-        centerSlopeAngle = GetSlopeAngle(centerNormal);
-        isOnSlope = centerSlopeAngle > 0.0f;
-    }
-
-    static int SortBySlopeAngle(Vector2 normal1, Vector2 normal2)
-    {
-        float angle1 = -Vector2.SignedAngle(normal1, Vector2.up);
-        float angle2 = -Vector2.SignedAngle(normal2, Vector2.up);
-
-        return angle1.CompareTo(angle2);
-    }
-
-    protected virtual bool IsPhysicallyGrounded()
-    {
-        if (slopes.Count <= 0 || !canWalkOnSlope)
-        {
-            return false;
-        }
-
-        return true;
-    }
-
-    private void CheckGround()
-    {
-        bool isOnGround = IsPhysicallyGrounded();
-
-        if (!isGrounded && isOnGround)
-        {
-            OnLand();
-        }
-
-        isGrounded = isOnGround;
-    }
-
-    private void ClearCollisionVariables()
-    {
-        slopes.Clear();
-    }
-
-    protected virtual void OnLand()
-    {
-        onLandEvent.Invoke();
-    }
-
     protected void ApplyGravity()
     {
-        if (!isGrounded || !canWalkOnSlope)
+        if (!slopeComponent.isGrounded || !slopeComponent.canWalkOnSlope)
         {
             velocity.y = GetNewVelocity(velocity.y, -maxFallSpeed, gravity);
         }
-        else if (isOnSlope)
+        else if (slopeComponent.isOnSlope)
         {
             ApplySlopeGravity();
         }
@@ -252,7 +58,7 @@ public class PhysicsUnit : BaseUnit
 
     protected virtual void ApplySlopeGravity()
     {
-        Vector2 slopeDirection = centerSlopeDirection.x > 0.0f ? centerSlopeDirection : -centerSlopeDirection;
+        Vector2 slopeDirection = Mathf.Sign(slopeComponent.centerSlopeDirection.x) * slopeComponent.centerSlopeDirection;
         Vector2 projectedVelocity = Vector3.Project(velocity, slopeDirection);
 
         velocity.x = GetNewVelocity(projectedVelocity.x, -maxFallSpeed * slopeDirection.x, gravity * slopeDirection.x);

--- a/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Character/PhysicsUnit.cs
@@ -32,7 +32,7 @@ public class PhysicsUnit : BaseUnit
     {
         if (!slopeComponent.isGrounded || !slopeComponent.canWalkOnSlope)
         {
-            velocityComponent.velocity.y = GetNewVelocity(velocityComponent.velocity.y, -maxFallSpeed, gravity);
+            velocityComponent.velocity.y = Velocity.GetNewVelocity(velocityComponent.velocity.y, -maxFallSpeed, gravity);
         }
         else if (slopeComponent.isOnSlope)
         {
@@ -49,22 +49,9 @@ public class PhysicsUnit : BaseUnit
         Vector2 slopeDirection = Mathf.Sign(slopeComponent.centerSlopeDirection.x) * slopeComponent.centerSlopeDirection;
         Vector2 projectedVelocity = Vector3.Project(velocityComponent.velocity, slopeDirection);
 
-        velocityComponent.velocity.x = GetNewVelocity(projectedVelocity.x, -maxFallSpeed * slopeDirection.x, gravity * slopeDirection.x);
-        velocityComponent.velocity.y = GetNewVelocity(projectedVelocity.y, -maxFallSpeed * slopeDirection.y, gravity * slopeDirection.y);
+        velocityComponent.velocity.x = Velocity.GetNewVelocity(projectedVelocity.x, -maxFallSpeed * slopeDirection.x, gravity * slopeDirection.x);
+        velocityComponent.velocity.y = Velocity.GetNewVelocity(projectedVelocity.y, -maxFallSpeed * slopeDirection.y, gravity * slopeDirection.y);
     }
 
-    protected float GetNewVelocity(float currentVelocity, float targetVelocity, float accelerationRate)
-    {
-        int direction = currentVelocity > targetVelocity ? -1 : 1;
-        float acceleration = Mathf.Abs(accelerationRate * Time.fixedDeltaTime);
-        float newVelocity = currentVelocity + acceleration * direction;
-        float velocityDifference = Mathf.Abs(currentVelocity - targetVelocity);
 
-        if (velocityDifference < acceleration)
-        {
-            return targetVelocity;
-        }
-
-        return newVelocity;
-    }
 }

--- a/Runelight-Smash-2021/Assets/Scripts/Component.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Component.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5711423e3e40304a9f982b89ac44da2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/Component/AirMovementComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/AirMovementComponent.cs
@@ -2,6 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(JoystickComponent))]
+[RequireComponent(typeof(SlopeComponent))]
+[RequireComponent(typeof(VelocityComponent))]
+
 public class AirMovementComponent : MonoBehaviour
 {
     // Required Variables

--- a/Runelight-Smash-2021/Assets/Scripts/Component/AirMovementComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/AirMovementComponent.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AirMovementComponent : MonoBehaviour
+{
+    // Required Variables
+    public float maxAirSpeed = 3.0f;
+    public float airAccelerationRate = 8.0f;
+    public float airDecelerationRate = 10.0f;
+
+    // Required Components
+    protected JoystickComponent joystickComponent;
+    protected SlopeComponent slopeComponent;
+    protected VelocityComponent velocityComponent;
+
+    void Start()
+    {
+        slopeComponent = GetComponent<SlopeComponent>();
+        joystickComponent = GetComponent<JoystickComponent>();
+        velocityComponent = GetComponent<VelocityComponent>();
+    }
+
+    void FixedUpdate()
+    {
+        if (!slopeComponent.isGrounded)
+        {
+            ApplyAirMovement();
+        }
+    }
+
+    protected virtual void ApplyAirMovement()
+    {
+        if (Mathf.Abs(joystickComponent.joystick.x) > 0)
+        {
+            velocityComponent.velocity.x = Velocity.GetNewVelocity(velocityComponent.velocity.x, joystickComponent.joystick.x * maxAirSpeed, airAccelerationRate);
+        }
+        else
+        {
+            velocityComponent.velocity.x = Velocity.GetNewVelocity(velocityComponent.velocity.x, 0.0f, airDecelerationRate);
+        }
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/Component/AirMovementComponent.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/AirMovementComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c6cd50f2eb5934649aed9398016f5dc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 180
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/Component/GravityComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/GravityComponent.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GravityComponent : MonoBehaviour
+{
+    // Required Variables
+    public float gravity = 20.0f;
+    public float maxFallSpeed = 5.0f;
+
+    // Required Components
+    protected SlopeComponent slopeComponent;
+    protected VelocityComponent velocityComponent;
+
+    void Start()
+    {
+        slopeComponent = GetComponent<SlopeComponent>();
+        velocityComponent = GetComponent<VelocityComponent>();
+    }
+
+    void FixedUpdate()
+    {
+        ApplyGravity();
+    }
+
+    protected void ApplyGravity()
+    {
+        if (!slopeComponent.isGrounded || !slopeComponent.canWalkOnSlope)
+        {
+            velocityComponent.velocity.y = Velocity.GetNewVelocity(velocityComponent.velocity.y, -maxFallSpeed, gravity);
+        }
+        else if (slopeComponent.isOnSlope)
+        {
+            ApplySlopeGravity();
+        }
+        else
+        {
+            velocityComponent.velocity.y = 0.0f;
+        }
+    }
+
+    protected void ApplySlopeGravity()
+    {
+        if (slopeComponent.isOnSlope && slopeComponent.canWalkOnSlope)
+        {
+            return;
+        }
+        Vector2 slopeDirection = Mathf.Sign(slopeComponent.centerSlopeDirection.x) * slopeComponent.centerSlopeDirection;
+        Vector2 projectedVelocity = Vector3.Project(velocityComponent.velocity, slopeDirection);
+
+        velocityComponent.velocity.x = Velocity.GetNewVelocity(projectedVelocity.x, -maxFallSpeed * slopeDirection.x, gravity * slopeDirection.x);
+        velocityComponent.velocity.y = Velocity.GetNewVelocity(projectedVelocity.y, -maxFallSpeed * slopeDirection.y, gravity * slopeDirection.y);
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/Component/GravityComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/GravityComponent.cs
@@ -2,6 +2,9 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(SlopeComponent))]
+[RequireComponent(typeof(VelocityComponent))]
+
 public class GravityComponent : MonoBehaviour
 {
     // Required Variables

--- a/Runelight-Smash-2021/Assets/Scripts/Component/GravityComponent.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/GravityComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 84f9e9612b8d04245a0d869ad9f55c1b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 250
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/Component/GroundMovementComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/GroundMovementComponent.cs
@@ -1,0 +1,111 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GroundMovementComponent : MonoBehaviour
+{
+    // Required Variables
+    public float maxWalkSpeed = 5.0f;
+    public float walkAccelerationRate = 15.0f;
+    public float groundDecelerationRate = 40.0f;
+    public float initialDashSpeed = 6.0f;
+    public float dashAccelerationRate = 40.0f;
+    public float maxDashSpeed = 12.0f;
+
+    // Required Components
+    protected SlopeComponent slopeComponent;
+    protected JoystickComponent joystickComponent;
+    protected VelocityComponent velocityComponent;
+
+    // Public Ground Movement State
+    public bool isDashing = false;
+
+    // Ground Movement Variables
+    public bool isDashStarted = false;
+    protected float groundSpeed { get { return isDashing ? maxDashSpeed : Mathf.Abs(joystickComponent.joystick.x) * maxWalkSpeed; } }
+    protected float groundAccelerationRate { get { return isDashing ? dashAccelerationRate : walkAccelerationRate; } }
+
+    void Start()
+    {
+        slopeComponent = GetComponent<SlopeComponent>();
+        joystickComponent = GetComponent<JoystickComponent>();
+        velocityComponent = GetComponent<VelocityComponent>();
+    }
+
+    void FixedUpdate()
+    {
+        if (slopeComponent.isGrounded && slopeComponent.canWalkOnSlope)
+        {
+            ApplyGroundMovement();
+        }
+    }
+
+    protected virtual void ApplyGroundMovement()
+    {
+        if (isDashing && !isDashStarted)
+        {
+            Vector2 normalized = velocityComponent.velocity.normalized;
+
+            velocityComponent.velocity.x = initialDashSpeed * (joystickComponent.joystick.x > 0 ? Mathf.Abs(normalized.x) : -Mathf.Abs(normalized.x));
+            velocityComponent.velocity.y = initialDashSpeed * normalized.y;
+
+            isDashStarted = true;
+        }
+
+        float speed = Mathf.Sign(joystickComponent.joystick.x) * groundSpeed;
+        float acceleration = Mathf.Abs(joystickComponent.joystick.x) > 0 ? groundAccelerationRate : groundDecelerationRate;
+
+        if (slopeComponent.isOnSlope)
+        {
+            Vector2 slopeDirection = Mathf.Sign(slopeComponent.centerSlopeDirection.x) * slopeComponent.centerSlopeDirection;
+            Vector2 projectedVelocity = Vector3.Project(velocityComponent.velocity, slopeDirection);
+
+            velocityComponent.velocity.x = Velocity.GetNewVelocity(projectedVelocity.x, speed * slopeDirection.x, acceleration * slopeDirection.x);
+            velocityComponent.velocity.y = Velocity.GetNewVelocity(projectedVelocity.y, speed * slopeDirection.y, acceleration * slopeDirection.y);
+        }
+        else
+        {
+            velocityComponent.velocity.x = Velocity.GetNewVelocity(velocityComponent.velocity.x, speed, acceleration);
+        }
+
+        if (velocityComponent.velocity.x < 0.0f && slopeComponent.leftMostSlopeAngle > slopeComponent.maxSlopeAngle)
+        {
+            velocityComponent.velocity = Vector2.zero;
+            return;
+        }
+        else if (velocityComponent.velocity.x > 0.0f && slopeComponent.rightMostSlopeAngle > slopeComponent.maxSlopeAngle)
+        {
+            velocityComponent.velocity = Vector2.zero;
+            return;
+        }
+    }
+
+    public void SetDashInput(float direction)
+    {
+        if (direction < 0)
+        {
+            if (!isDashing)
+            {
+                Debug.Log("Dash Left");
+            }
+            isDashing = true;
+        }
+        else if (direction > 0)
+        {
+            if (!isDashing)
+            {
+                Debug.Log("Dash Right");
+            }
+            isDashing = true;
+        }
+        else
+        {
+            if (isDashing)
+            {
+                Debug.Log("Stop");
+                isDashing = false;
+                isDashStarted = false;
+            }
+        }
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/Component/GroundMovementComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/GroundMovementComponent.cs
@@ -2,6 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(SlopeComponent))]
+[RequireComponent(typeof(JoystickComponent))]
+[RequireComponent(typeof(VelocityComponent))]
+
 public class GroundMovementComponent : MonoBehaviour
 {
     // Required Variables

--- a/Runelight-Smash-2021/Assets/Scripts/Component/GroundMovementComponent.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/GroundMovementComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d73a4b183b76d7a438da8d332bbc668f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 150
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/Component/JoystickComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/JoystickComponent.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class JoystickComponent : MonoBehaviour
+{
+    public Vector2 joystick;
+
+    public void SetJoystickInput(Vector2 input)
+    {
+        joystick = input;
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/Component/JoystickComponent.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/JoystickComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2a6eb7800b90f184d9bf7d8dacc6ca8a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/Component/JumpComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/JumpComponent.cs
@@ -3,6 +3,12 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 
+[RequireComponent(typeof(AirMovementComponent))]
+[RequireComponent(typeof(SlopeComponent))]
+[RequireComponent(typeof(JoystickComponent))]
+[RequireComponent(typeof(VelocityComponent))]
+[RequireComponent(typeof(GravityComponent))]
+
 public class JumpComponent : MonoBehaviour
 {
     // Required Variables
@@ -11,7 +17,7 @@ public class JumpComponent : MonoBehaviour
     public float doubleJumpHeight = 3.0f;
     public int maxDoubleJumpCount = 1;
     public bool canJumpChangeDirection = true;
-    public float minSlopeJumpAngle = 15.0f;
+    public float minSlopeJumpAngle = 30.0f;
 
     // Required Components
     protected AirMovementComponent airMovementComponent;

--- a/Runelight-Smash-2021/Assets/Scripts/Component/JumpComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/JumpComponent.cs
@@ -1,0 +1,146 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class JumpComponent : MonoBehaviour
+{
+    // Required Variables
+    public float shortHopHeight = 1.5f;
+    public float fullHopHeight = 3.0f;
+    public float doubleJumpHeight = 3.0f;
+    public int maxDoubleJumpCount = 1;
+    public bool canJumpChangeDirection = true;
+    public float minSlopeJumpAngle = 15.0f;
+
+    // Required Components
+    protected AirMovementComponent airMovementComponent;
+    protected SlopeComponent slopeComponent;
+    protected JoystickComponent joystickComponent;
+    protected VelocityComponent velocityComponent;
+    protected GravityComponent gravityComponent;
+
+    // Public Jump States
+    public bool isJumpSquatting;
+    public bool isJumping;
+
+    // Jump Variables
+    protected JumpEventType jumpEventType = JumpEventType.None;
+    protected int doubleJumpLeft;
+
+    // Events
+    public UnityEvent onJumpEvent = new UnityEvent();
+
+    void Start()
+    {
+        airMovementComponent = GetComponent<AirMovementComponent>();
+        gravityComponent = GetComponent<GravityComponent>();
+        slopeComponent = GetComponent<SlopeComponent>();
+        joystickComponent = GetComponent<JoystickComponent>();
+        velocityComponent = GetComponent<VelocityComponent>();
+
+        slopeComponent.onLandEvent.AddListener(OnLand);
+        doubleJumpLeft = maxDoubleJumpCount;
+    }
+
+    void FixedUpdate()
+    {
+        ApplyJumpMovement();
+    }
+
+    protected virtual void ApplyJumpMovement()
+    {
+        switch (jumpEventType)
+        {
+            case JumpEventType.Start:
+                isJumpSquatting = true;
+                break;
+            case JumpEventType.ShortHop:
+                if (!slopeComponent.isGrounded)
+                {
+                    break;
+                }
+                ShortHop();
+                break;
+            case JumpEventType.FullHop:
+                if (!slopeComponent.isGrounded)
+                {
+                    break;
+                }
+                FullHop();
+                break;
+            case JumpEventType.DoubleJump:
+                if (slopeComponent.isGrounded)
+                {
+                    break;
+                }
+                DoubleJump();
+                break;
+        }
+        jumpEventType = JumpEventType.None;
+    }
+
+    private void ShortHop()
+    {
+        Jump(shortHopHeight);
+    }
+
+    private void FullHop()
+    {
+        Jump(fullHopHeight);
+    }
+
+    private void DoubleJump()
+    {
+        if (doubleJumpLeft <= 0)
+        {
+            return;
+        }
+        doubleJumpLeft -= 1;
+        Jump(doubleJumpHeight);
+    }
+
+    private void Jump(float jumpHeight)
+    {
+        float targetJumpSpeed = joystickComponent.joystick.x > 0 ? Mathf.Max(joystickComponent.joystick.x * airMovementComponent.maxAirSpeed, velocityComponent.velocity.x) : Mathf.Min(joystickComponent.joystick.x * airMovementComponent.maxAirSpeed, velocityComponent.velocity.x);
+        float jumpSpeed = canJumpChangeDirection ? targetJumpSpeed : velocityComponent.velocity.x;
+        Vector2 jumpVelocity = new Vector2(jumpSpeed, Mathf.Sqrt(2.0f * gravityComponent.gravity * jumpHeight));
+        float jumpAngle = Vector2.Angle(Vector2.right, jumpVelocity);
+        float slopeAngle = Mathf.Sign(velocityComponent.velocity.y) * slopeComponent.centerSlopeAngle;
+
+        // Make sure jump velocityComponent.velocity is away from the grounds
+        if (jumpVelocity.x < 0.0f && 180 - jumpAngle < slopeAngle + minSlopeJumpAngle)
+        {
+            float rotateAngle = Mathf.Deg2Rad * -((slopeAngle - (180 - jumpAngle)) + minSlopeJumpAngle);
+            float cos = Mathf.Cos(rotateAngle);
+            float sin = Mathf.Sin(rotateAngle);
+
+            jumpVelocity.x = jumpVelocity.x * cos - jumpVelocity.y * sin;
+        }
+        else if (jumpVelocity.x > 0.0f && jumpAngle < slopeAngle + minSlopeJumpAngle)
+        {
+            float rotateAngle = Mathf.Deg2Rad * (slopeAngle - jumpAngle + minSlopeJumpAngle);
+            float cos = Mathf.Cos(rotateAngle);
+            float sin = Mathf.Sin(rotateAngle);
+
+            jumpVelocity.x = jumpVelocity.x * cos - jumpVelocity.y * sin;
+        }
+
+        velocityComponent.velocity = jumpVelocity;
+        isJumpSquatting = false;
+        isJumping = true;
+        slopeComponent.isGrounded = false;
+        onJumpEvent.Invoke();
+    }
+
+    protected void OnLand()
+    {
+        doubleJumpLeft = maxDoubleJumpCount;
+        isJumping = false;
+    }
+
+    public void SetJumpInput(JumpEventType input)
+    {
+        jumpEventType = input;
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/Component/JumpComponent.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/JumpComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b62cf03d15c02c8418d2d840bf853d55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 190
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/Component/SlopeComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/SlopeComponent.cs
@@ -1,0 +1,216 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class SlopeComponent : MonoBehaviour
+{
+    // Required Variables
+    public LayerMask groundLayerMask;
+    public float maxSlopeAngle = 45.0f;
+
+    // Required Components
+    protected CapsuleCollider2D capsule;
+    protected Rigidbody2D unitRigidbody;
+
+    // Public Slope States
+    public bool isGrounded;
+    public bool isOnSlope = false;
+    public float leftMostSlopeAngle = 0.0f;
+    public float centerSlopeAngle = 0.0f;
+    public float rightMostSlopeAngle = 0.0f;
+    public Vector2 leftMostSlopeDirection;
+    public Vector2 centerSlopeDirection;
+    public Vector2 rightMostSlopeDirection;
+    public bool canWalkOnSlope;
+
+    // Events
+    public UnityEvent onLandEvent = new UnityEvent();
+
+    // Slope calculation variables
+    private List<Vector2> slopes = new List<Vector2>();
+    private ContactFilter2D filter = new ContactFilter2D();
+    protected float CAST_OFFSET = 0.1f;
+
+    // Collision variables
+    private ContactPoint2D[] contactPoints = new ContactPoint2D[10];
+    private RaycastHit2D[] hits = new RaycastHit2D[10];
+
+    void Start()
+    {
+        unitRigidbody = GetComponent<Rigidbody2D>();
+        capsule = GetComponent<CapsuleCollider2D>();
+        filter.SetLayerMask(groundLayerMask);
+    }
+
+    void FixedUpdate()
+    {
+        if (!unitRigidbody.IsSleeping())
+        {
+            CheckSlope();
+            CheckGround();
+            ClearCollisionVariables();
+        }
+    }
+
+    private void CheckSlope()
+    {
+        GetSlopeCollisionPoints();
+
+        if (slopes.Count <= 0)
+        {
+            return;
+        }
+        CalculateSlopes();
+
+        canWalkOnSlope = centerSlopeAngle <= maxSlopeAngle;
+    }
+
+    private void GetSlopeCollisionPoints()
+    {
+        Vector2 centerPos = unitRigidbody.position + capsule.offset;
+        Vector2 feetPos = centerPos - Vector2.up * (capsule.size.y - capsule.size.x) / 2;
+        float distance = (centerPos - feetPos).y;
+        int count = Physics2D.CircleCast(centerPos, capsule.size.x / 2, Vector2.down, filter, hits, distance + CAST_OFFSET);
+
+        for (int i = 0; i < count; i++)
+        {
+            RaycastHit2D hit = hits[i];
+
+            if (hit.point.y >= centerPos.y - distance)
+            {
+                continue;
+            }
+
+            Vector2 slopeDirection = AddToSlopes(hit);
+
+            // CircleCast returns only one collision per object, so perform CircleCast again to get more collision points
+            RaycastHit2D extraHit = Physics2D.CircleCast(feetPos, capsule.size.x / 2, slopeDirection.y < 0.0f ? slopeDirection : -slopeDirection, CAST_OFFSET, groundLayerMask);
+            if (extraHit)
+            {
+                AddToSlopes(extraHit);
+            }
+        }
+    }
+
+    protected virtual bool IsPhysicallyGrounded()
+    {
+        if (slopes.Count <= 0 || !canWalkOnSlope)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private void CheckGround()
+    {
+        bool isOnGround = IsPhysicallyGrounded();
+
+        if (!isGrounded && isOnGround)
+        {
+            OnLand();
+        }
+
+        isGrounded = isOnGround;
+    }
+
+    protected virtual void OnLand()
+    {
+        onLandEvent.Invoke();
+    }
+
+    private Vector2 AddToSlopes(RaycastHit2D hit)
+    {
+        Vector2 normal = hit.normal;
+        Vector2 slopeDirection = GetSignedSlopeDirection(normal);
+
+        slopes.Add(normal);
+        Debug.DrawRay(hit.point, slopeDirection.y < 0.0f ? -slopeDirection : slopeDirection, Color.red);
+
+        return slopeDirection;
+    }
+
+    public Vector2 GetSignedSlopeDirection(Vector2 normal)
+    {
+        return -Vector2.Perpendicular(normal).normalized;
+    }
+
+    public Vector2 GetSlopeDirection(Vector2 normal)
+    {
+        Vector2 signedSlopeDirection = GetSignedSlopeDirection(normal);
+
+        return signedSlopeDirection.y < 0.0f ? -signedSlopeDirection : signedSlopeDirection;
+    }
+
+    public float GetSignedSlopeAngle(Vector2 normal)
+    {
+        return -Vector2.SignedAngle(normal, Vector2.up);
+    }
+
+    public float GetSlopeAngle(Vector2 normal)
+    {
+        float signedSlopeAngle = GetSignedSlopeAngle(normal);
+
+        return Mathf.Abs(signedSlopeAngle);
+    }
+
+    private void CalculateSlopes()
+    {
+        if (slopes.Count <= 0)
+        {
+            leftMostSlopeDirection = Vector2.zero;
+            rightMostSlopeDirection = Vector2.zero;
+            centerSlopeDirection = Vector2.zero;
+            leftMostSlopeAngle = 0.0f;
+            rightMostSlopeAngle = 0.0f;
+            centerSlopeAngle = 0.0f;
+            return;
+        }
+
+        slopes.Sort(SortBySlopeAngle);
+
+        // Get the steepest slope angle on the left and right
+        Vector2 leftMostNormal = slopes[0];
+        Vector2 rightMostNormal = slopes[slopes.Count - 1];
+        Vector2 centerNormal = Vector2.up;
+        Vector2 leftMost = GetSignedSlopeDirection(leftMostNormal);
+        Vector2 rightMost = GetSignedSlopeDirection(rightMostNormal);
+        float left = GetSignedSlopeAngle(leftMostNormal);
+        float right = GetSignedSlopeAngle(rightMostNormal);
+
+        if (left < 0.0f && right > 0.0f)
+        {
+            centerNormal = leftMostNormal + rightMostNormal;
+        }
+        else if (left < 0.0f)
+        {
+            centerNormal = rightMostNormal;
+        }
+        else if (right > 0.0f)
+        {
+            centerNormal = leftMostNormal;
+        }
+
+        leftMostSlopeDirection = left < 0.0f ? GetSlopeDirection(leftMostNormal) : Vector2.zero;
+        rightMostSlopeDirection = right > 0.0f ? GetSlopeDirection(rightMostNormal) : Vector2.zero;
+        leftMostSlopeAngle = Vector2.SignedAngle(leftMostSlopeDirection, Vector2.left);
+        rightMostSlopeAngle = -Vector2.SignedAngle(rightMostSlopeDirection, Vector2.right);
+        centerSlopeDirection = GetSlopeDirection(centerNormal);
+        centerSlopeAngle = GetSlopeAngle(centerNormal);
+        isOnSlope = centerSlopeAngle > 0.0f;
+    }
+
+    static int SortBySlopeAngle(Vector2 normal1, Vector2 normal2)
+    {
+        float angle1 = -Vector2.SignedAngle(normal1, Vector2.up);
+        float angle2 = -Vector2.SignedAngle(normal2, Vector2.up);
+
+        return angle1.CompareTo(angle2);
+    }
+
+    private void ClearCollisionVariables()
+    {
+        slopes.Clear();
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/Component/SlopeComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/SlopeComponent.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
 
+[RequireComponent(typeof(CapsuleCollider2D))]
+[RequireComponent(typeof(Rigidbody2D))]
+
 public class SlopeComponent : MonoBehaviour
 {
     // Required Variables

--- a/Runelight-Smash-2021/Assets/Scripts/Component/SlopeComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/SlopeComponent.cs
@@ -123,36 +123,12 @@ public class SlopeComponent : MonoBehaviour
     private Vector2 AddToSlopes(RaycastHit2D hit)
     {
         Vector2 normal = hit.normal;
-        Vector2 slopeDirection = GetSignedSlopeDirection(normal);
+        Vector2 slopeDirection = Slope.GetSignedSlopeDirection(normal);
 
         slopes.Add(normal);
         Debug.DrawRay(hit.point, slopeDirection.y < 0.0f ? -slopeDirection : slopeDirection, Color.red);
 
         return slopeDirection;
-    }
-
-    public Vector2 GetSignedSlopeDirection(Vector2 normal)
-    {
-        return -Vector2.Perpendicular(normal).normalized;
-    }
-
-    public Vector2 GetSlopeDirection(Vector2 normal)
-    {
-        Vector2 signedSlopeDirection = GetSignedSlopeDirection(normal);
-
-        return signedSlopeDirection.y < 0.0f ? -signedSlopeDirection : signedSlopeDirection;
-    }
-
-    public float GetSignedSlopeAngle(Vector2 normal)
-    {
-        return -Vector2.SignedAngle(normal, Vector2.up);
-    }
-
-    public float GetSlopeAngle(Vector2 normal)
-    {
-        float signedSlopeAngle = GetSignedSlopeAngle(normal);
-
-        return Mathf.Abs(signedSlopeAngle);
     }
 
     private void CalculateSlopes()
@@ -168,16 +144,16 @@ public class SlopeComponent : MonoBehaviour
             return;
         }
 
-        slopes.Sort(SortBySlopeAngle);
+        slopes.Sort(Slope.SortBySlopeAngle);
 
         // Get the steepest slope angle on the left and right
         Vector2 leftMostNormal = slopes[0];
         Vector2 rightMostNormal = slopes[slopes.Count - 1];
         Vector2 centerNormal = Vector2.up;
-        Vector2 leftMost = GetSignedSlopeDirection(leftMostNormal);
-        Vector2 rightMost = GetSignedSlopeDirection(rightMostNormal);
-        float left = GetSignedSlopeAngle(leftMostNormal);
-        float right = GetSignedSlopeAngle(rightMostNormal);
+        Vector2 leftMost = Slope.GetSignedSlopeDirection(leftMostNormal);
+        Vector2 rightMost = Slope.GetSignedSlopeDirection(rightMostNormal);
+        float left = Slope.GetSignedSlopeAngle(leftMostNormal);
+        float right = Slope.GetSignedSlopeAngle(rightMostNormal);
 
         if (left < 0.0f && right > 0.0f)
         {
@@ -192,21 +168,13 @@ public class SlopeComponent : MonoBehaviour
             centerNormal = leftMostNormal;
         }
 
-        leftMostSlopeDirection = left < 0.0f ? GetSlopeDirection(leftMostNormal) : Vector2.zero;
-        rightMostSlopeDirection = right > 0.0f ? GetSlopeDirection(rightMostNormal) : Vector2.zero;
+        leftMostSlopeDirection = left < 0.0f ? Slope.GetSlopeDirection(leftMostNormal) : Vector2.zero;
+        rightMostSlopeDirection = right > 0.0f ? Slope.GetSlopeDirection(rightMostNormal) : Vector2.zero;
         leftMostSlopeAngle = Vector2.SignedAngle(leftMostSlopeDirection, Vector2.left);
         rightMostSlopeAngle = -Vector2.SignedAngle(rightMostSlopeDirection, Vector2.right);
-        centerSlopeDirection = GetSlopeDirection(centerNormal);
-        centerSlopeAngle = GetSlopeAngle(centerNormal);
+        centerSlopeDirection = Slope.GetSlopeDirection(centerNormal);
+        centerSlopeAngle = Slope.GetSlopeAngle(centerNormal);
         isOnSlope = centerSlopeAngle > 0.0f;
-    }
-
-    static int SortBySlopeAngle(Vector2 normal1, Vector2 normal2)
-    {
-        float angle1 = -Vector2.SignedAngle(normal1, Vector2.up);
-        float angle2 = -Vector2.SignedAngle(normal2, Vector2.up);
-
-        return angle1.CompareTo(angle2);
     }
 
     private void ClearCollisionVariables()

--- a/Runelight-Smash-2021/Assets/Scripts/Component/SlopeComponent.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/SlopeComponent.cs.meta
@@ -1,10 +1,10 @@
 fileFormatVersion: 2
-guid: 7f45e4acb7a8cee4eb91fe97d8476438
+guid: c3c6a524bab19044c91693cb39279ea4
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 200
+  executionOrder: 100
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/Runelight-Smash-2021/Assets/Scripts/Component/SlopeStickComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/SlopeStickComponent.cs
@@ -1,0 +1,104 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SlopeStickComponent : MonoBehaviour
+{
+    // Required Components
+    protected CapsuleCollider2D capsule;
+    protected Rigidbody2D unitRigidbody;
+    protected AirMovementComponent airMovementComponent;
+    protected GravityComponent gravityComponent;
+    protected JoystickComponent joystickComponent;
+    protected JumpComponent jumpComponent;
+    protected SlopeComponent slopeComponent;
+    protected VelocityComponent velocityComponent;
+
+    // Slope Stick Variable
+    private Vector2 slopeStickPosition;
+
+    void Start()
+    {
+        capsule = GetComponent<CapsuleCollider2D>();
+        unitRigidbody = GetComponent<Rigidbody2D>();
+        airMovementComponent = GetComponent<AirMovementComponent>();
+        gravityComponent = GetComponent<GravityComponent>();
+        joystickComponent = GetComponent<JoystickComponent>();
+        jumpComponent = GetComponent<JumpComponent>();
+        slopeComponent = GetComponent<SlopeComponent>();
+        velocityComponent = GetComponent<VelocityComponent>();
+    }
+
+    void FixedUpdate()
+    {
+        StickToSlope();
+    }
+
+    private void StickToSlope()
+    {
+        if (jumpComponent.isJumping || !slopeComponent.isGrounded || !slopeComponent.canWalkOnSlope)
+        {
+            return;
+        }
+        RaycastHit2D hit;
+        float distanceToFeetPos = (capsule.size.y - capsule.size.x) / 2;
+        float radius = capsule.size.x / 2;
+        Vector2 centerPos = unitRigidbody.position + capsule.offset;
+        Vector2 feetPos = centerPos - Vector2.up * distanceToFeetPos;
+        Vector2 nextVelocityStep = velocityComponent.velocity * Time.fixedDeltaTime;
+        Vector2 nextPos = centerPos + nextVelocityStep;
+
+        hit = Physics2D.CircleCast(feetPos, radius, nextVelocityStep, nextVelocityStep.magnitude, slopeComponent.groundLayerMask);
+
+        if (hit)
+        {
+            float nextSlopeAngle = Slope.GetSlopeAngle(hit.normal);
+
+            if (nextSlopeAngle > slopeComponent.maxSlopeAngle)
+            {
+                slopeStickPosition = hit.centroid;
+                Vector2 newSlopeStickPosition = slopeStickPosition + Vector2.up * (distanceToFeetPos - capsule.offset.y);
+
+                Debug.DrawLine(unitRigidbody.position, newSlopeStickPosition, Color.white);
+                velocityComponent.ForceToPosition(newSlopeStickPosition);
+                return;
+            }
+        }
+
+        hit = Physics2D.CircleCast(nextPos, radius, Vector2.down, velocityComponent.velocity.magnitude, slopeComponent.groundLayerMask);
+
+        if (hit)
+        {
+            Vector2 perpendicular = Vector2.Perpendicular(hit.normal);
+            Vector2 nextSlopeDirection = perpendicular.x > 0.0f ? perpendicular : -perpendicular;
+            float nextSlopeAngle = Vector2.Angle(perpendicular, Vector2.left);
+
+            if (nextSlopeAngle > slopeComponent.maxSlopeAngle)
+            {
+                return;
+            }
+            Ray2D ray1 = new Ray2D(feetPos - Vector2.up * Physics2D.defaultContactOffset, nextVelocityStep);
+            Ray2D ray2 = new Ray2D(hit.centroid, velocityComponent.velocity.x < 0.0f ? nextSlopeDirection : -nextSlopeDirection);
+
+            if (!Math2D.IsRayIntersecting(ray1, ray2))
+            {
+                return;
+            }
+
+            slopeStickPosition = hit.centroid;
+            Vector2 newSlopeStickPosition = slopeStickPosition + Vector2.up * (distanceToFeetPos - capsule.offset.y);
+
+            Debug.DrawLine(unitRigidbody.position, newSlopeStickPosition, Color.white);
+            velocityComponent.ForceToPosition(newSlopeStickPosition);
+        }
+    }
+
+    void OnDrawGizmosSelected()
+    {
+        if (capsule != null)
+        {
+            UnityEditor.Handles.color = Color.green;
+            UnityEditor.Handles.DrawWireDisc(slopeStickPosition, Vector3.forward, capsule.size.x / 2);
+        }
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/Component/SlopeStickComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/SlopeStickComponent.cs
@@ -2,6 +2,15 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(CapsuleCollider2D))]
+[RequireComponent(typeof(Rigidbody2D))]
+[RequireComponent(typeof(AirMovementComponent))]
+[RequireComponent(typeof(GravityComponent))]
+[RequireComponent(typeof(JoystickComponent))]
+[RequireComponent(typeof(JumpComponent))]
+[RequireComponent(typeof(SlopeComponent))]
+[RequireComponent(typeof(VelocityComponent))]
+
 public class SlopeStickComponent : MonoBehaviour
 {
     // Required Components

--- a/Runelight-Smash-2021/Assets/Scripts/Component/SlopeStickComponent.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/SlopeStickComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7e153cf66ff3d1347ba1503e05e9ee71
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 280
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/Component/VelocityComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/VelocityComponent.cs
@@ -1,0 +1,61 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class VelocityComponent : MonoBehaviour
+{
+    // Required Components
+    protected Rigidbody2D unitRigidbody;
+
+    // Public Slope States
+    public Vector2 velocity;
+    public bool isMovementEnabled { get { return _isMovementEnabled; } }
+
+    private bool _isMovementEnabled = true;
+    private bool isPositionForced = false;
+    private Vector2 forcePosition;
+
+    void Start()
+    {
+        unitRigidbody = GetComponent<Rigidbody2D>();
+    }
+
+    void FixedUpdate()
+    {
+        if (isMovementEnabled)
+        {
+            ApplyVelocity();
+        }
+    }
+
+    protected void ApplyVelocity()
+    {
+        if (isPositionForced)
+        {
+            unitRigidbody.position = forcePosition;
+            isPositionForced = false;
+            return;
+        }
+        unitRigidbody.MovePosition(unitRigidbody.position + velocity * Time.fixedDeltaTime);
+    }
+
+    public void DisableMovement()
+    {
+        _isMovementEnabled = false;
+        unitRigidbody.velocity = Vector2.zero;
+        unitRigidbody.isKinematic = true;
+    }
+
+    public void EnableMovement()
+    {
+        _isMovementEnabled = true;
+        unitRigidbody.velocity = Vector2.zero;
+        unitRigidbody.isKinematic = false;
+    }
+
+    public void ForceToPosition(Vector2 position)
+    {
+        isPositionForced = true;
+        forcePosition = position;
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/Component/VelocityComponent.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/VelocityComponent.cs
@@ -2,6 +2,8 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
+[RequireComponent(typeof(Rigidbody2D))]
+
 public class VelocityComponent : MonoBehaviour
 {
     // Required Components

--- a/Runelight-Smash-2021/Assets/Scripts/Component/VelocityComponent.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Component/VelocityComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c809f4e2f671eb4c893c3cbbe443e51
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 300
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -9,6 +9,7 @@ public class FighterController : MonoBehaviour
     private FighterActionHandler fighterActionHandler;
     private FighterUnit fighterUnit;
     private JoystickComponent joystickComponent;
+    private GroundMovementComponent groundMovementComponent;
 
     public bool isShielding = false;
 
@@ -19,6 +20,7 @@ public class FighterController : MonoBehaviour
         fighterActionHandler = GetComponent<FighterActionHandler>();
         fighterUnit = GetComponent<FighterUnit>();
         joystickComponent = GetComponent<JoystickComponent>();
+        groundMovementComponent = GetComponent<GroundMovementComponent>();
 
         BindActionEvents();
     }
@@ -74,7 +76,7 @@ public class FighterController : MonoBehaviour
 
     private void HandleDash(float direction)
     {
-        fighterUnit.SetDashInput(direction);
+        groundMovementComponent.SetDashInput(direction);
     }
 
     // Mock jump simulation

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -10,6 +10,7 @@ public class FighterController : MonoBehaviour
     private FighterUnit fighterUnit;
     private JoystickComponent joystickComponent;
     private GroundMovementComponent groundMovementComponent;
+    private JumpComponent jumpComponent;
 
     public bool isShielding = false;
 
@@ -21,7 +22,7 @@ public class FighterController : MonoBehaviour
         fighterUnit = GetComponent<FighterUnit>();
         joystickComponent = GetComponent<JoystickComponent>();
         groundMovementComponent = GetComponent<GroundMovementComponent>();
-
+        jumpComponent = GetComponent<JumpComponent>();
         BindActionEvents();
     }
 
@@ -33,13 +34,11 @@ public class FighterController : MonoBehaviour
         fighterActionHandler.shieldEvent.AddListener(HandleShield);
         fighterActionHandler.grabEvent.AddListener(HandleGrab);
         fighterActionHandler.dashEvent.AddListener(HandleDash);
-
-        fighterUnit.onJumpEvent.AddListener(Jump);
     }
 
     private void HandleJump(JumpEventType jumpEventType)
     {
-        fighterUnit.SetJumpInput(jumpEventType);
+        jumpComponent.SetJumpInput(jumpEventType);
     }
 
     private void HandleMovement(Vector2 direction)
@@ -77,12 +76,6 @@ public class FighterController : MonoBehaviour
     private void HandleDash(float direction)
     {
         groundMovementComponent.SetDashInput(direction);
-    }
-
-    // Mock jump simulation
-    public void Jump()
-    {
-        // playerInput.SwitchCurrentActionMap("Airborne");
     }
 
     public void Land()

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -31,7 +31,6 @@ public class FighterController : MonoBehaviour
         fighterActionHandler.dashEvent.AddListener(HandleDash);
 
         fighterUnit.onJumpEvent.AddListener(Jump);
-        fighterUnit.onLandEvent.AddListener(Land);
     }
 
     private void HandleJump(JumpEventType jumpEventType)

--- a/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/FighterController.cs
@@ -8,6 +8,7 @@ public class FighterController : MonoBehaviour
     private PlayerInput playerInput;
     private FighterActionHandler fighterActionHandler;
     private FighterUnit fighterUnit;
+    private JoystickComponent joystickComponent;
 
     public bool isShielding = false;
 
@@ -17,6 +18,7 @@ public class FighterController : MonoBehaviour
         playerInput = GetComponent<PlayerInput>();
         fighterActionHandler = GetComponent<FighterActionHandler>();
         fighterUnit = GetComponent<FighterUnit>();
+        joystickComponent = GetComponent<JoystickComponent>();
 
         BindActionEvents();
     }
@@ -40,7 +42,7 @@ public class FighterController : MonoBehaviour
 
     private void HandleMovement(Vector2 direction)
     {
-        fighterUnit.SetJoystickInput(direction);
+        joystickComponent.SetJoystickInput(direction);
     }
 
     private void HandleRoll(Vector2 direction)

--- a/Runelight-Smash-2021/Assets/Scripts/Util/Slope.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Util/Slope.cs
@@ -1,0 +1,36 @@
+using UnityEngine;
+
+public static class Slope
+{
+    public static Vector2 GetSignedSlopeDirection(Vector2 normal)
+    {
+        return -Vector2.Perpendicular(normal).normalized;
+    }
+
+    public static Vector2 GetSlopeDirection(Vector2 normal)
+    {
+        Vector2 signedSlopeDirection = GetSignedSlopeDirection(normal);
+
+        return signedSlopeDirection.y < 0.0f ? -signedSlopeDirection : signedSlopeDirection;
+    }
+
+    public static float GetSignedSlopeAngle(Vector2 normal)
+    {
+        return -Vector2.SignedAngle(normal, Vector2.up);
+    }
+
+    public static float GetSlopeAngle(Vector2 normal)
+    {
+        float signedSlopeAngle = GetSignedSlopeAngle(normal);
+
+        return Mathf.Abs(signedSlopeAngle);
+    }
+
+    public static int SortBySlopeAngle(Vector2 normal1, Vector2 normal2)
+    {
+        float angle1 = -Vector2.SignedAngle(normal1, Vector2.up);
+        float angle2 = -Vector2.SignedAngle(normal2, Vector2.up);
+
+        return angle1.CompareTo(angle2);
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/Util/Slope.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Util/Slope.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e574d7032d6fbc94daedcd2ec8b89d86
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runelight-Smash-2021/Assets/Scripts/Util/Velocity.cs
+++ b/Runelight-Smash-2021/Assets/Scripts/Util/Velocity.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+
+public static class Velocity
+{
+    public static float GetNewVelocity(float currentVelocity, float targetVelocity, float accelerationRate)
+    {
+        int direction = currentVelocity > targetVelocity ? -1 : 1;
+        float acceleration = Mathf.Abs(accelerationRate * Time.fixedDeltaTime);
+        float newVelocity = currentVelocity + acceleration * direction;
+        float velocityDifference = Mathf.Abs(currentVelocity - targetVelocity);
+
+        if (velocityDifference < acceleration)
+        {
+            return targetVelocity;
+        }
+
+        return newVelocity;
+    }
+}

--- a/Runelight-Smash-2021/Assets/Scripts/Util/Velocity.cs.meta
+++ b/Runelight-Smash-2021/Assets/Scripts/Util/Velocity.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 75a905e9ae0c9e647bad838306caa8a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 이슈 번호
* N/A

## 작업 내역
* 기존에 BaseUnit => PhysicsUnit => ControllableUnit => FighterUnit 순으로 상속받으며 추가됬던 각종 기능들을 모두 Component 로 분리
* 이에 따라 기존 Tick 에서 상속받으며 관리했던 Component 실행 순서를 프로젝트 세팅에서 관리하도록 수정: 

![캡처5](https://user-images.githubusercontent.com/16410221/129372881-660b4eb9-2f78-424c-893f-6d0c77c5d4b4.PNG)

* `[RequireComponent]` 매크로 적용하여 에러를 최대한 방지할 수 있도록 구성

## 리뷰받고 싶은 Point
* N/A
